### PR TITLE
Fix visual overlap of nodes on cross-lane bezier edges in commit graph

### DIFF
--- a/streamlit_ui/utils.py
+++ b/streamlit_ui/utils.py
@@ -47,15 +47,19 @@ def create_tensors(ds: Any, schema: Dict[str, Dict[str, Any]]) -> Optional[str]:
         return f"Failed to create tensors: {e}"
 
 
-def add_samples(ds: Any, data: Dict[str, List], auto_commit: bool = True,
-                 commit_message: str = "Add samples via Streamlit UI") -> Optional[str]:
+def add_samples(
+    ds: Any,
+    data: Dict[str, List],
+    auto_commit: bool = True,
+    commit_message: Optional[str] = None,
+) -> Optional[str]:
     """Add samples to dataset using per-tensor extend."""
     try:
         with ds:
             for tensor_name, values in data.items():
                 ds[tensor_name].extend(values)
         if auto_commit:
-            ds.commit(message=commit_message)
+            ds.commit(message=commit_message or "Add samples via Streamlit UI")
         return None
     except Exception as e:
         return f"Failed to add samples: {e}"
@@ -361,18 +365,64 @@ def render_commit_graph_html(graph_data: Dict[str, Any], height: int = 500) -> s
 
   const svg = document.getElementById("graph");
   const tip = document.getElementById("tip");
-  const maxD = D.max_depth || 0;
-  const W = LM + (maxD + 1) * COL + 40;
-  const H = TM + D.lane_count * LANE + 24;
-  svg.setAttribute("width", W);
-  svg.setAttribute("height", H);
-  svg.setAttribute("viewBox", `0 0 ${{W}} ${{H}}`);
 
   /* ── Compute node positions ── */
   const pos = {{}};
   D.commits.forEach(c => {{
     pos[c.id] = {{ x: LM + c.depth * COL, y: TM + c.lane * LANE }};
   }});
+
+  /* ── Nudge nodes that sit on cross-lane bezier edges ──
+   * For bezier M sx,sy C mx,sy mx,dy dx,dy the y-parametric is:
+   *   y(t) = sy·(1-t)²·(1+2t) + dy·t²·(3-2t)
+   * We solve for t at each intermediate lane's y via bisection,
+   * then check if any unrelated node's x is within OV_THRESH of the
+   * curve's x(t). If so, shift that node right by NUDGE_PX.
+   */
+  const NUDGE_PX = Math.round(COL * 0.22);
+  const OV_THRESH = R + 4;
+  function _solveT(sy, dy, tgt) {{
+    let lo = 0, hi = 1;
+    for (let i = 0; i < 25; i++) {{
+      const t = (lo + hi) / 2, u = 1 - t;
+      const yt = sy * u * u * (1 + 2 * t) + dy * t * t * (3 - 2 * t);
+      if ((dy > sy) === (yt < tgt)) lo = t; else hi = t;
+    }}
+    return (lo + hi) / 2;
+  }}
+  function _bezX(t, sx, mx, dx) {{
+    const u = 1 - t;
+    return u * u * u * sx + 3 * u * t * mx + t * t * t * dx;
+  }}
+  const nudged = new Set();
+  D.commits.forEach(c => {{
+    ["parent_id", "merge_parent_id"].forEach(key => {{
+      const pid = c[key];
+      if (!pid || !pos[pid]) return;
+      const s = pos[pid], d = pos[c.id];
+      if (s.y === d.y) return;
+      const emx = (s.x + d.x) / 2;
+      const minY = Math.min(s.y, d.y), maxY = Math.max(s.y, d.y);
+      D.commits.forEach(o => {{
+        if (o.id === pid || o.id === c.id || nudged.has(o.id)) return;
+        const ny = pos[o.id].y;
+        if (ny <= minY || ny >= maxY) return;
+        const t = _solveT(s.y, d.y, ny);
+        const bx = _bezX(t, s.x, emx, d.x);
+        if (Math.abs(pos[o.id].x - bx) < OV_THRESH) {{
+          pos[o.id].x += NUDGE_PX;
+          nudged.add(o.id);
+        }}
+      }});
+    }});
+  }});
+
+  const maxD = D.max_depth || 0;
+  const W = LM + (maxD + 1) * COL + 40 + (nudged.size > 0 ? NUDGE_PX : 0);
+  const H = TM + D.lane_count * LANE + 24;
+  svg.setAttribute("width", W);
+  svg.setAttribute("height", H);
+  svg.setAttribute("viewBox", `0 0 ${{W}} ${{H}}`);
 
   /* ── Layer 1: branch lane rails (subtle dashed lines) ── */
   D.branches.forEach(b => {{


### PR DESCRIPTION
## Summary

- Fix a visual ambiguity in the version control commit graph where cross-lane bezier edges could pass directly through unrelated nodes
- Add a post-layout nudge pass that detects geometric overlaps and shifts affected nodes slightly to the right

## Problem

When a cross-lane edge (e.g., from `fb0db7d9` on `main` to `b64539b3` on `dev-2`) is rendered as a cubic bezier, it may visually pierce through an unrelated node on an intermediate lane (e.g., `763145a3` on `dev-1`), making the graph ambiguous — it looks as if the edge connects to that node.

This happens because the bezier `M sx,sy C mx,sy mx,dy dx,dy` passes through the exact geometric midpoint `((sx+dx)/2, (sy+dy)/2)` at `t=0.5`, which coincides with an intermediate lane's y-coordinate whenever the edge spans 2+ lanes.

## Solution

After computing initial node positions and before rendering, a new pass:

1. Iterates over every cross-lane bezier edge (both parent and merge edges)
2. For each unrelated node whose y falls between the edge's source and destination y, solves the bezier's y-parametric equation `y(t) = sy·(1-t)²·(1+2t) + dy·t²·(3-2t)` for `t` via bisection
3. Computes the bezier's x at that `t` and checks if the node is within `R + 4` px
4. If overlapping, nudges the node `COL * 0.22` px (~15px) to the right

All edges connected to the nudged node automatically render from/to the updated position, preserving visual consistency. SVG width is expanded to accommodate any nudges.

### Cases handled

| Case | Handled |
|------|---------|
| Edge spans multiple intermediate lanes (e.g., lane 0 → lane 3) | Yes — each intermediate lane is checked |
| Merge edges (dashed beziers) | Yes — both `parent_id` and `merge_parent_id` edges are checked |
| Upward edges (e.g., dev-2 merging into main) | Yes — bisection works for both increasing and decreasing y |
| Multiple nodes overlapping different edges | Yes — each is nudged independently, tracked via `Set` to avoid double-nudging |

### Visual Effect:
* Before:
<img width="1128" height="240" alt="Screenshot 2026-03-24 at 11 06 27 PM" src="https://github.com/user-attachments/assets/ce44d003-565d-4f33-98ce-1622000b9c4b" />
* After:
<img width="1182" height="262" alt="image" src="https://github.com/user-attachments/assets/35a1b4b7-0b5e-4e2a-9279-3bd4b6c1cfbb" />



## Test plan

- [x] Simulated the algorithm on the exact graph topology from the reported case; confirmed `763145a3` is detected (0.0px from curve) and nudged from x=230 to x=245
- [x] Visual verification with the Streamlit demo using `/Users/sherrylin/muller_datasets`
- [ ] Test with datasets that have 4+ branches to verify multi-lane edge cases