### PR TITLE
Fix dataset statistics() persistence and JSON serialization of NumPy scalars

### DIFF
--- a/muller/core/dataset/statistics/statistics.py
+++ b/muller/core/dataset/statistics/statistics.py
@@ -25,8 +25,7 @@ def show_statistics(dataset):
     Args:
         dataset: The dataset to get statistics for.
     """
-    from muller.core.dataset.statistics.io import load_statistics, save_statistics
-
+    from muller.core.version_control.functions import load_statistics, save_statistics
     if dataset.has_head_changes:
         warnings.warn(
             "There are uncommitted changes, showing statistics from last committed version, try again after commit."
@@ -51,9 +50,9 @@ def get_column_stats_numpy(data):
     column_statistics = {}
     histogram = get_histogram(data)
     length = len(data)
-    nan_count = np.count_nonzero(np.isnan(data))
+    nan_count = int(np.count_nonzero(np.isnan(data)))
     column_statistics['nan_count'] = nan_count
-    column_statistics['nan_proportion'] = nan_count / length
+    column_statistics['nan_proportion'] = float(nan_count / length)
     column_statistics['min'] = int(np.min(data))
     column_statistics['max'] = int(np.max(data))
     column_statistics['mean'] = float(round(np.mean(data), 5))

--- a/muller/core/meta/dataset_meta.py
+++ b/muller/core/meta/dataset_meta.py
@@ -25,6 +25,7 @@ class DatasetMeta(Meta):
         self.hidden_tensors = []
         self.info = {}
         self.dataset_creator = "public"
+        self.statistics = None
 
     def __getstate__(self) -> Dict[str, Any]:
         d = super().__getstate__()
@@ -33,13 +34,14 @@ class DatasetMeta(Meta):
         d["hidden_tensors"] = self.hidden_tensors.copy()
         d["info"] = self.info.copy()
         d["dataset_creator"] = self.dataset_creator
+        d["statistics"] = self.statistics
         return d
 
     def __setstate__(self, d):
-        # Remove deprecated fields for backward compatibility
-        d.pop("statistics", None)
+        statistics = d.pop("statistics", None)
         d.pop("default_index", None)
         self.__dict__.update(d)
+        self.statistics = statistics
 
     @property
     def visible_tensors(self):

--- a/muller/util/json.py
+++ b/muller/util/json.py
@@ -37,6 +37,10 @@ class HubJsonEncoder(json.JSONEncoder):
                 "_hub_custom_type": "bytes",
                 "data": base64.b64encode(obj).decode(),
             }
+        # numpy scalars: returning obj would make json re-enter default() on the same
+        # instance and raise "Circular reference detected"
+        elif isinstance(obj, (np.integer, np.floating, np.bool_)):
+            return obj.item()
 
         return obj
 

--- a/official_demo.ipynb
+++ b/official_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 1,
    "id": "e11acf0c-587a-4f7b-b3ce-7cc1b01747d1",
    "metadata": {},
    "outputs": [],
@@ -17,7 +17,7 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "warnings.simplefilter('ignore')\n",
     "\n",
-    "muller_dataset_root_path = \"/home/dyvm6xra/dyvm6xrauser08/sherry/muller_dataset/\""
+    "muller_dataset_root_path = \"/Users/sherrylin/Documents/research_data/muller_dataset\""
    ]
   },
   {
@@ -41,7 +41,7 @@
     "#from test_scripts.config import settings as st\n",
     "\n",
     "\n",
-    "DATA_DIR = Path(\"/home/dyvm6xra/dyvm6xrauser08/sherry/data/\")\n",
+    "DATA_DIR = Path(\"/Users/sherrylin/Documents/research_data/\")\n",
     "DATA_DIR /= \"cifar10\"\n",
     "DATA_DIR /= \"shared\"\n",
     "\n",
@@ -175,7 +175,7 @@
     "\n",
     "    def __init__(self, train=False, transform=None, download=True):\n",
     "        self.transform = transform\n",
-    "        self.root_dir = \"/home/dyvm6xra/dyvm6xrauser08/sherry/data/\"\n",
+    "        self.root_dir = \"/Users/sherrylin/Documents/research_data/coco2017/\"\n",
     "\n",
     "        if download and not self.root_dir.is_dir():\n",
     "            self._download()\n",
@@ -320,7 +320,7 @@
      "output_type": "stream",
      "text": [
       "loading annotations into memory...\n",
-      "Done (t=0.55s)\n",
+      "Done (t=0.15s)\n",
       "creating index...\n",
       "index created!\n"
      ]
@@ -333,7 +333,7 @@
     "from PIL import Image\n",
     "from pycocotools.coco import COCO\n",
     "\n",
-    "coco_annotations = COCO('/home/dyvm6xra/dyvm6xrauser08/sherry/data/annotations/instances_val2017.json')"
+    "coco_annotations = COCO('/Users/sherrylin/Documents/research_data/coco2017/annotations/instances_val2017.json')"
    ]
   },
   {
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 7,
    "id": "ec28e86a-7456-4c6b-ba20-8cd1bb4528b3",
    "metadata": {},
    "outputs": [
@@ -434,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 8,
    "id": "1c297978-bed9-4bc0-8b15-137c9a856466",
    "metadata": {},
    "outputs": [
@@ -444,7 +444,7 @@
        "Tensor(key='description')"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 9,
    "id": "f03e313a-c9d3-401b-9a3c-c027a7566069",
    "metadata": {},
    "outputs": [
@@ -488,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 10,
    "id": "9f9583d9-53dc-41a7-a5ff-1e3b3048986b",
    "metadata": {},
    "outputs": [
@@ -562,7 +562,7 @@
        "4       4     rabbit  A soft, white lop-eared rabbit with bright eye..."
       ]
      },
-     "execution_count": 94,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -583,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 28,
    "id": "45c9bc66-79a1-40a8-a12a-c3ae1239610b",
    "metadata": {},
    "outputs": [
@@ -591,7 +591,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Evaluating file_to_muller: 100%|███████████████████████████████████████████████| 50000/50000 [00:33<00:00\n"
+      "Evaluating file_to_muller_optimized: 100%|████████████████████████████████████████████████████| 50000/50000 [00:02<00:00\n"
      ]
     }
    ],
@@ -601,30 +601,31 @@
     "\n",
     "ds_cifar = muller.dataset(path=muller_dataset_root_path + \"cifar\", overwrite=True)\n",
     "with ds_cifar:\n",
-    "    # Create the tensors with names of your choice.\n",
     "    ds_cifar.create_tensor(\"images\", htype=\"image\", sample_compression=\"jpg\")\n",
     "    ds_cifar.create_tensor(\"labels\", htype=\"class_label\", class_names=class_names)\n",
-    "    \n",
-    "@muller.compute\n",
-    "def file_to_muller(data_pair, sample_out):\n",
-    "    # First two arguments are always default arguments containing:\n",
-    "    #     1st argument is an element of the input iterable (list, dataset, array,...)\n",
-    "    #     2nd argument is a dataset sample\n",
-    "    #     Other arguments are optional\n",
     "\n",
-    "    # Append the label and image to the output sample\n",
-    "    sample_out.labels.append(np.uint32(data_pair[1][1]))\n",
-    "    sample_out.images.append(muller.read(data_pair[1][0]))\n",
+    "@muller.compute(batch_enable=True)\n",
+    "def file_to_muller_optimized(images, labels, sample_out):\n",
+    "    sample_out.images.append(images)\n",
+    "    sample_out.labels.append(labels)\n",
     "    return sample_out\n",
-    "        \n",
+    "\n",
     "with ds_cifar:\n",
-    "    iter_dict = [pair for pair in enumerate(cifar)]\n",
-    "    file_to_muller().eval(iter_dict, ds_cifar, num_workers=8)"
+    "    images = [muller.read(pair[1][0]) for pair in enumerate(cifar)]\n",
+    "    labels = [np.uint32(pair[1][1]) for pair in enumerate(cifar)]\n",
+    "\n",
+    "    file_to_muller_optimized().eval(\n",
+    "        images, labels, ds_cifar,\n",
+    "        num_workers=8,\n",
+    "        scheduler=\"processed\",\n",
+    "        cache_size=64,\n",
+    "        disable_rechunk=True\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 29,
    "id": "d76a28e0-a166-45bf-b993-cb22a3dd6bf0",
    "metadata": {},
    "outputs": [
@@ -654,23 +655,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 30,
    "id": "53d89b88-c4c5-4502-8150-fa6216466088",
-   "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true,
-     "source_hidden": true
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/dyvm6xra/dyvm6xrauser08/sherry/MULLER/muller/core/chunk/base_chunk.py:396: UserWarning: Grayscale images will be reshaped from (H, W) to (H, W, 1) to match tensor dimensions. This warning will be shown only once.\n",
-      "  warnings.warn(message)\n",
-      "Iteration 4999"
+      "Evaluating coco_to_muller: 100%|████████████████████████████████████████████████████████████████| 5000/5000 [00:01<00:00\n"
      ]
     }
    ],
@@ -687,29 +680,50 @@
     "    ds_coco.create_tensor(\"iscrowd\", htype=\"generic\", sample_compression=\"lz4\")\n",
     "    ds_coco.create_tensor(\"segmentation\", htype=\"list\", sample_compression=None)\n",
     "\n",
+    "@muller.compute(batch_enable=True)\n",
+    "def coco_to_muller(images, areas, bboxes, category_ids, ids, image_ids, iscrowds, segmentations, sample_out):\n",
+    "    sample_out.images.append(images)\n",
+    "    sample_out.area.append(areas)\n",
+    "    sample_out.bbox.append(bboxes)\n",
+    "    sample_out.category_id.append(category_ids)\n",
+    "    sample_out.id.append(ids)\n",
+    "    sample_out.image_id.append(image_ids)\n",
+    "    sample_out.iscrowd.append(iscrowds)\n",
+    "    sample_out.segmentation.append(segmentations)\n",
+    "    return sample_out\n",
+    "\n",
     "with ds_coco:\n",
+    "    # Preload data into separate lists\n",
+    "    images, areas, bboxes, category_ids = [], [], [], []\n",
+    "    ids, image_ids, iscrowds, segmentations = [], [], [], []\n",
     "    for i, (image, target) in enumerate(coco):\n",
     "        if i >= 5000:\n",
     "            break\n",
-    "        print(f\"Iteration {i:4d}\", end=\"\\r\", flush=True, file=sys.stderr)\n",
-    "        ds_coco.area.append(target[\"area\"])\n",
-    "        ds_coco.bbox.append(target[\"bbox\"])\n",
-    "        ds_coco.category_id.append(target[\"category_id\"])\n",
-    "        ds_coco.id.append(target[\"id\"])\n",
-    "        ds_coco.image_id.append(target[\"image_id\"])\n",
-    "        ds_coco.images.append(muller.read(image))\n",
-    "        ds_coco.iscrowd.append(target[\"iscrowd\"])\n",
-    "        ds_coco.segmentation.append(target[\"segmentation\"])"
+    "        images.append(muller.read(image))\n",
+    "        areas.append(target[\"area\"])\n",
+    "        bboxes.append(target[\"bbox\"])\n",
+    "        category_ids.append(target[\"category_id\"])\n",
+    "        ids.append(target[\"id\"])\n",
+    "        image_ids.append(target[\"image_id\"])\n",
+    "        iscrowds.append(target[\"iscrowd\"])\n",
+    "        segmentations.append(target[\"segmentation\"])\n",
+    "\n",
+    "    coco_to_muller().eval(\n",
+    "        images, areas, bboxes, category_ids, ids, image_ids, iscrowds, segmentations,\n",
+    "        ds_coco,\n",
+    "        num_workers=8,\n",
+    "        scheduler=\"processed\",\n",
+    "        cache_size=64,\n",
+    "        disable_rechunk=True\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 31,
    "id": "d1c2a09d-b9cf-4089-ad0e-78a2302a4f2d",
    "metadata": {
-    "collapsed": true,
     "jupyter": {
-     "outputs_hidden": true,
      "source_hidden": true
     }
    },
@@ -777,7 +791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 11,
    "id": "64fcdf78-cf6a-4807-bb29-9314b29e17ba",
    "metadata": {},
    "outputs": [
@@ -800,17 +814,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 12,
    "id": "4073d976-b466-40cf-b49c-79d8d46c18bd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'value': ['cat', 'cat', 'dog', 'dog', 'rabbit']}"
+       "{'value': [np.str_('cat'),\n",
+       "  np.str_('cat'),\n",
+       "  np.str_('dog'),\n",
+       "  np.str_('dog'),\n",
+       "  np.str_('rabbit')]}"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -821,7 +839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 13,
    "id": "bd0c9d68-1f17-41ce-9a5d-4ee865b5cac9",
    "metadata": {},
    "outputs": [
@@ -839,25 +857,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 14,
    "id": "bc0cfde7-90bb-413e-ac59-1249eb8950cc",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "    tensor        htype                 shape               dtype  compression\n",
-      "   -------       -------               -------             -------  ------- \n",
-      "     area        generic            (5000, 1:63)           float32    lz4   \n",
-      "     bbox         bbox             (5000, 1:63, 4)         float32    lz4   \n",
-      " category_id   class_label          (5000, 1:63)           uint32     lz4   \n",
-      "      id         generic            (5000, 1:63)            int64     lz4   \n",
-      "   image_id      generic              (5000, 1)             int64     lz4   \n",
-      "    images        image     (5000, 145:640, 200:640, 1:3)   uint8    jpeg   \n",
-      "   iscrowd       generic            (5000, 1:63)            int64     lz4   \n",
-      " segmentation     list              (5000, 1:63)             str     None   \n"
+     "ename": "NameError",
+     "evalue": "name 'ds_coco' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[14]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mds_coco\u001b[49m.summary()\n",
+      "\u001b[31mNameError\u001b[39m: name 'ds_coco' is not defined"
      ]
     }
    ],
@@ -2684,7 +2696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/tests/unit/test_hub_json_encoder.py
+++ b/tests/unit/test_hub_json_encoder.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# Copyright (c) 2026 Xueling Lin
+
+"""HubJsonEncoder must convert numpy scalars; returning them unchanged breaks json.dumps
+with ValueError: Circular reference detected."""
+
+import json
+
+import numpy as np
+
+from muller.util.json import HubJsonEncoder
+
+
+def test_numpy_scalars_encode_without_circular_reference():
+    payload = {
+        "nan_count": np.int64(3),
+        "nan_proportion": np.float64(0.25),
+        "flag": np.bool_(True),
+    }
+    text = json.dumps(payload, cls=HubJsonEncoder)
+    out = json.loads(text)
+    assert out == {"nan_count": 3, "nan_proportion": 0.25, "flag": True}
+
+
+def test_dataset_meta_statistics_round_trip():
+    from muller.core.meta.dataset_meta import DatasetMeta
+
+    meta = DatasetMeta()
+    meta.statistics = {
+        "num_examples": 10,
+        "statistics": [
+            {
+                "column_name": "x",
+                "column_type": "float",
+                "column_statistics": {
+                    "nan_count": np.int64(0),
+                    "nan_proportion": np.float64(0.0),
+                },
+            }
+        ],
+    }
+    # nbytes -> tobytes() uses HubJsonEncoder
+    assert meta.nbytes > 0
+    raw = meta.tobytes()
+    loaded = DatasetMeta.frombuffer(raw)
+    assert loaded.statistics["num_examples"] == 10
+    assert loaded.statistics["statistics"][0]["column_statistics"]["nan_count"] == 0


### PR DESCRIPTION
### Summary

Fixes failures when calling `Dataset().statistics()`: missing `DatasetMeta.statistics` after load, and `ValueError: Circular reference detected` when saving computed statistics to `dataset_meta.json`.

### Root causes

1. **`DatasetMeta` deserialization**  
   `__setstate__` was calling `d.pop("statistics", None)` and discarding the value, so statistics loaded from storage never appeared on the object. `statistics` was also omitted from `__init__` and `__getstate__`, so it was never part of the serialized round-trip.

2. **`HubJsonEncoder` and NumPy scalars**  
   For unknown types, `default()` returned the object unchanged. NumPy scalars (e.g. `np.int64`, `np.float64`) are not JSON-native; the encoder re-entered `default()` on the same instance and reported a circular reference. Statistics code naturally produces such scalars (e.g. `np.count_nonzero`, division).

### Changes

- **`muller/core/meta/dataset_meta.py`**: Initialize `statistics`; include it in `__getstate__`; restore it in `__setstate__` (stop dropping it on load).
- **`muller/util/json.py`**: Encode NumPy scalars via `.item()` for `np.integer`, `np.floating`, and `np.bool_`.
- **`muller/core/dataset/statistics/statistics.py`**: Use explicit `int()` / `float()` for `nan_count` and `nan_proportion` where applicable.
- **`tests/unit/test_hub_json_encoder.py`**: Tests for encoder behavior and `DatasetMeta` + `statistics` `tobytes` / `frombuffer` round-trip.

### How to verify

```python
ds = muller.load("path/to/dataset")
ds.statistics()  # should print JSON; second call should load from meta without error