### PR TITLE
fix: surface worker-process failures in index build/optimize/reshard

### DIFF
--- a/muller/core/query/inverted_index_vectorized.py
+++ b/muller/core/query/inverted_index_vectorized.py
@@ -300,11 +300,18 @@ class InvertedIndexVectorized(object):
                 raise ExecuteError from e
         else:
             pool = multiprocessing.Pool(num_process)
-            for i in range(num_of_shards):
+            # Collect AsyncResults so worker exceptions propagate to the
+            # main process via ``.get()`` below, instead of being silently
+            # swallowed by ``close() + join()``.
+            results = [
                 pool.apply_async(func=self._merge_shards,
-                                args=(optimize_mode, i,))
+                                 args=(optimize_mode, i,))
+                for i in range(num_of_shards)
+            ]
             pool.close()
             pool.join()
+            for res in results:
+                res.get()
 
         # Rename the original index folder (if it exists) to col_[uuid].
         # Then, rename the col_optimized folder to col, and delete the col_tmp folder.
@@ -396,9 +403,10 @@ class InvertedIndexVectorized(object):
             optimize_batch = [pool.apply_async(func=self._reshard_single,
                                                args=(i, old_shard_num, new_shard_num))
                               for i in range(old_shard_num)]
-            # Wait for all the above tasks to be finished
+            # Use ``.get()`` rather than ``.wait()`` so worker exceptions
+            # propagate to the main process instead of being silently dropped.
             for res in optimize_batch:
-                res.wait()
+                res.get()
 
     def add_hot_shard(self, max_workers: int = 16, n: int = 100000):
         """Select the top n most frequently occurring terms from the existing shards
@@ -719,7 +727,14 @@ class InvertedIndexVectorized(object):
             'num_shards': batch_params['num_of_shards']
         }
 
-        for i, start in enumerate(ranges[0]):
+        # Collect AsyncResults so worker exceptions propagate to the main
+        # process via ``.get()`` below. Previously this loop was fire-and-
+        # forget, which made every worker-side failure (unpicklable args,
+        # ``spawn`` re-importing an unfindable ``__main__`` under hosts like
+        # ``streamlit run`` or ``jupyter``, read-only storage, etc.) invisible
+        # — the only trace was a missing batch-completion marker that later
+        # made ``check_index_completeness`` return "unfinished".
+        results = [
             pool.apply_async(
                 func=self._process_index,
                 args=(
@@ -730,9 +745,13 @@ class InvertedIndexVectorized(object):
                     tokenizer_params
                 )
             )
+            for i, start in enumerate(ranges[0])
+        ]
 
         pool.close()
         pool.join()
+        for res in results:
+            res.get()
 
 
     def _check_index_completion(self, num_of_batches):
@@ -826,8 +845,10 @@ class InvertedIndexVectorized(object):
 
         tokenizer_params['num_shards'] = num_of_shards
 
-        # Submit the task
-        for i, start in enumerate(ranges[0]):
+        # Submit the tasks. Collect AsyncResults so worker exceptions
+        # propagate via ``.get()`` below instead of being silently dropped
+        # (see analogous comment in ``_create_python_index``).
+        results = [
             pool.apply_async(
                 func=self._process_index,
                 args=(
@@ -838,9 +859,13 @@ class InvertedIndexVectorized(object):
                     tokenizer_params
                 )
             )
+            for i, start in enumerate(ranges[0])
+        ]
 
         pool.close()
         pool.join()
+        for res in results:
+            res.get()
 
 
     def _check_update_completion(self, num_of_batches):
@@ -960,7 +985,11 @@ class InvertedIndexVectorized(object):
             self._log_completion(self.index_folder + "_tmp", batch_count, start)
 
         except Exception as e:
+            # Log then re-raise so the caller's ``AsyncResult.get()`` surfaces
+            # the real error in the main process instead of silently leaving a
+            # missing batch-completion marker behind.
             self.logger.info(f"{batch_count} creation fails because of {e}")
+            raise
 
 
     def _add_to_shard(self, shards, data, line_num, num_of_shards):
@@ -1035,7 +1064,11 @@ class InvertedIndexVectorized(object):
             self.logger.info(f"merged shards: {shard_id}")
 
         except Exception as e:
+            # Log then re-raise so the caller's ``AsyncResult.get()`` surfaces
+            # the real error in the main process instead of silently leaving a
+            # half-merged optimized folder behind.
             self.logger.info(f"{shard_id} merge fails because of {e}")
+            raise
 
 
     def _load_index(self, shard_id):


### PR DESCRIPTION
## Summary

The multi-process code paths in `InvertedIndexVectorized` use a fire-and-forget `pool.apply_async(...); pool.close(); pool.join()` pattern (or `res.wait()`) and pair it with worker-side `try/except Exception` blocks that only log and then return normally. As a result, **every worker-side failure is silently dropped** — the only trace is a missing batch-completion marker or a half-merged optimized folder, which later makes `check_index_completeness` return "unfinished" or leaves `meta.json` never written. The top-level call still returns normally with at most a `warnings.warn("Create index fails.")`, so the caller (and tests) cannot tell anything went wrong.

This PR is a minimal, single-file fix that makes these failures **propagate as real exceptions** in the main process.

## How the bug surfaces for users

A recent real-world example that this PR catches: running `ds.create_index_vectorized("description")` under `streamlit run demo_streamlit.py` on macOS / Python 3.8+. The default `multiprocessing` start method there is `spawn`, which re-imports `__main__` in each worker — under `streamlit run` that `__main__` resolves to `streamlit.web.cli`, not the user script, so workers die before running `_process_index`.

Pre-fix: zero batch-completion markers, silent `warnings.warn("Create index fails.")`, no `meta.json` entry, and subsequent `CONTAINS` queries raise the misleading `"You need to create inverted index on the tensor column (description)..."`.

Post-fix: the actual root-cause exception (e.g. `ReadOnlyModeError`, a worker import failure, a tokenizer crash) is raised at the call site.

The same class of bug was also previously hiding real failures under Jupyter, Celery, Tornado, and other multi-threaded / non-importable-`__main__` hosts.

## What changed

All changes are in `muller/core/query/inverted_index_vectorized.py` (+40 / −7 lines):

**Worker side** — log then re-raise (so the exception can propagate):

- `_process_index`
- `_merge_shards`

**Caller side** — collect `AsyncResult`s and call `.get()` after `close() + join()` (or in place of `.wait()`):

- `_create_python_index`
- `_update_with_python` (the update-path worker submission)
- `optimize_index` non-cpp branch
- `reshard_index` (swap `.wait()` → `.get()`)

The companion call sites in the same file (`add_hot_shard`, `_parallel_complex_search`, `_parallel_search`) already call `.get()` and are intentionally left untouched.

## Behaviour impact

- **Successful index builds are byte-for-byte identical** to before (same files written, same `meta.json`, same `optimize_index` behaviour).
- **Failing index builds now raise** instead of silently succeeding with "unfinished" state. This is a strict improvement in observability — callers can now actually know whether their index was built.
- No public API or signature change; no new dependencies.

## Test plan

- [x] Ran `tests/integration/indexing/test_inverted_index_local.py` under `fork` start method (Linux CI default) locally on macOS: **all 5 Python-path tests pass** (`test_inverted_index[False]`, `test_show_progress[False]`, `test_complex_fuzzy_match[False]`, `test_inverted_index_with_multi_user`, `test_create_new_index_while_using_old_index`). The remaining 5 fail only because my local dev box does not compile the `muller.util.sparsehash.build` C++ extension — unrelated to this PR, which only touches Python paths.
- [x] Verified end-to-end via a standalone writable-dataset script (create text tensor → commit → `create_index_vectorized` → `filter_vectorized(CONTAINS)`): success flow unchanged.
- [x] Confirmed the fix resolves the Streamlit `CONTAINS` failure scenario that motivated it (with a separate host-side `ThreadPool` shim; the shim is still useful to actually run the index build in that host, but surfacing the error is a prerequisite and belongs in the library regardless).

## Follow-ups (out of scope of this PR)

- Consider allowing callers to opt in to a thread pool for hosts where `multiprocessing.Pool` cannot be used (Streamlit/Jupyter/Tornado). The scope/design question is non-trivial (API surface, semantics of `num_workers`, etc.) and deserves its own discussion.
- `_parallel_search` / `_parallel_complex_search` / `add_hot_shard` already use `.get()` but their workers do not catch-and-log — verify those behave identically after this change (no change expected; no-op in the current pass).
