### PR TITLE
feat: unified Query & Search, saved-view workflow, user-aware view permissions (Streamlit UI)

### DIFF
--- a/streamlit_ui/demo_streamlit.py
+++ b/streamlit_ui/demo_streamlit.py
@@ -35,8 +35,13 @@ from utils import (
     is_coco2017_muller_schema, load_coco_category_id_to_name,
     pil_overlay_coco_bboxes, DEFAULT_COCO_INSTANCES_JSON,
     branch_ops, benchmark_parquet_vs_muller,
-    load_dataset, commit_dataset, get_dataset_info,
+    load_dataset, release_dataset_lock, commit_dataset, get_dataset_info,
     build_commit_graph_data, render_commit_graph_html,
+    classify_deletable_branches,
+    list_vector_tensor_names, list_vector_indexes, parse_query_vector,
+    run_vector_search, ensure_vector_index, tensor_embedding_dim,
+    save_query_view, list_saved_views, load_saved_view, delete_saved_view,
+    get_view_entry, current_user, set_current_user,
 )
 import streamlit.components.v1 as components
 import pandas as pd
@@ -82,9 +87,11 @@ def _dm_coco_thumb_page_delta(delta: int, max_page: int) -> None:
 def _ensure_dataset():
     """Reload the dataset object from path if it was lost across reruns."""
     if st.session_state.dataset is None and st.session_state.dataset_path:
-        ds, err = load_dataset(st.session_state.dataset_path)
+        ds, err, warn = load_dataset(st.session_state.dataset_path)
         if err is None:
             st.session_state.dataset = ds
+            if warn:
+                st.session_state["_load_warning"] = warn
 
 
 _ensure_dataset()
@@ -115,6 +122,26 @@ _dm_fullres_dialog = (
 st.sidebar.title("🗄️ MULLER Demo")
 st.sidebar.markdown("**Multimodal Data Lake with Git-like Versioning**")
 
+# -- Current user (for multi-user / permission demos) -----------------------
+# SensitiveConfig is a process singleton, so setting it here affects every
+# subsequent MULLER call in this Streamlit process — exactly the semantics we
+# need to act as different engineers within a single demo session.
+_cur_user = current_user()
+_user_input = st.sidebar.text_input(
+    "👤 Current user",
+    value=_cur_user,
+    key="current_user_input",
+    help="MULLER permission checks (branch ownership, delete_view, …) "
+    "compare against this uid. Change it here to impersonate another engineer "
+    "and exercise the permission model.",
+)
+if _user_input.strip() and _user_input.strip() != _cur_user:
+    new_uid = set_current_user(_user_input)
+    st.sidebar.success(f"Acting as `{new_uid}`.")
+    st.rerun()
+
+st.sidebar.markdown("---")
+
 page = st.sidebar.radio(
     "Navigation",
     ["📊 Dataset Management", "🔍 Query & Search",
@@ -128,6 +155,13 @@ if st.session_state.dataset is not None:
     st.sidebar.info(f"Branch: `{info.get('branch', '?')}`")
     if info.get("has_uncommitted"):
         st.sidebar.warning("Uncommitted changes")
+    # Surface read-only fallback prominently: it silently blocks commits,
+    # inverted-index creation, and most write paths.
+    if getattr(st.session_state.dataset, "read_only", False):
+        st.sidebar.error(
+            "Read-only mode — write lock unavailable. "
+            "Close other holders and reload."
+        )
 else:
     st.sidebar.warning("No dataset loaded")
 
@@ -273,14 +307,23 @@ if page == "📊 Dataset Management":
                 if not load_path:
                     st.error("Please enter a path")
                 else:
-                    ds, error = load_dataset(load_path)
+                    # Release the previous dataset's write lock first; otherwise
+                    # re-loading the same path in the same Streamlit session
+                    # races itself for the lock and falls back to read-only.
+                    release_dataset_lock(st.session_state.dataset)
+                    st.session_state.dataset = None
+
+                    ds, error, warn = load_dataset(load_path)
                     if error:
                         st.error(error)
                     else:
                         st.session_state.dataset = ds
                         st.session_state.dataset_path = load_path
                         st.session_state.current_branch = ds.branch
+                        st.session_state["_load_warning"] = warn  # may be None
                         st.success(f"Dataset loaded from: {load_path}")
+                        if warn:
+                            st.warning(warn)
                         st.rerun()
 
     # --- Tab 2: View & Edit ---
@@ -995,12 +1038,134 @@ elif page == "🔍 Query & Search":
         ds = st.session_state.dataset
         tensor_names = list(ds.tensors.keys())
 
-        tab_filter, tab_vector = st.tabs(["Conditional Filtering", "Vector Search"])
+        # Result of the most recent query/view load lives across reruns so the
+        # user can scroll, tweak display options, and then save it as a view
+        # without losing it. Invalidated whenever the dataset identity changes.
+        _qs_ctx = (st.session_state.get("dataset_path"), ds.branch, len(ds))
+        if st.session_state.get("_qs_result_ctx") != _qs_ctx:
+            st.session_state["_qs_result_ctx"] = _qs_ctx
+            st.session_state["qs_result_ds"] = None
+            st.session_state["qs_result_desc"] = None
+            st.session_state["qs_result_meta"] = None
 
-        with tab_filter:
+        # ── Saved views (expander at top) ──────────────────────────────────
+        _me = current_user()
+        with st.expander(f"📁 Saved Views · you are `{_me}`", expanded=False):
+            col_refresh, _ = st.columns([1, 6])
+            with col_refresh:
+                if st.button("Refresh", key="qs_views_refresh"):
+                    st.rerun()
+            view_rows, view_err = list_saved_views(ds)
+            if view_err:
+                st.error(view_err)
+            if view_rows:
+                # Decorate each row so the table makes ownership obvious at a glance.
+                _display_rows = [
+                    {
+                        "owner": f"👤 you ({r['owner']})" if r["owner"] == _me
+                        else f"{r['owner']} (read-only)",
+                        "id": r["id"],
+                        "message": r["message"],
+                        "commit": r["commit_id"],
+                        "virtual": r["virtual"],
+                    }
+                    for r in view_rows
+                ]
+                st.dataframe(pd.DataFrame(_display_rows), width="stretch", hide_index=True)
+            else:
+                st.caption("No views saved yet. Run a query below and save the result.")
+
+            # owner_of[view_id] → owner uid, so the Delete button can gate itself.
+            owner_of = {r["id"]: r["owner"] for r in view_rows}
+            existing_ids = list(owner_of.keys())
+
+            col_sel, col_input = st.columns(2)
+            with col_sel:
+                picked = st.selectbox(
+                    "Pick from saved views",
+                    options=["(type an ID instead)"] + existing_ids,
+                    key="qs_view_pick",
+                )
+            with col_input:
+                typed = st.text_input(
+                    "…or type a view ID",
+                    key="qs_view_typed",
+                    help="Takes precedence over the dropdown when non-empty.",
+                )
+            target_vid = typed.strip() or (picked if picked != "(type an ID instead)" else "")
+            _target_owner = owner_of.get(target_vid) if target_vid else None
+            _is_mine = (_target_owner == _me) if _target_owner else False
+
+            col_load, col_del = st.columns(2)
+            with col_load:
+                if st.button("Load View", type="primary", key="qs_view_load",
+                             disabled=(not target_vid)):
+                    view_ds, view_entry, err = load_saved_view(ds, target_vid)
+                    if err:
+                        st.error(err)
+                    else:
+                        st.session_state["qs_result_ds"] = view_ds
+                        st.session_state["qs_result_desc"] = (
+                            f"View `{target_vid}` (length = {len(view_ds)})"
+                        )
+                        _owner = str(view_entry.get("uid") or "-") if view_entry else "-"
+                        st.session_state["qs_result_meta"] = {
+                            "source": "view",
+                            "view_id": target_vid,
+                            "owner": _owner,
+                            "is_mine": _owner == _me,
+                            "source_commit": getattr(view_entry, "commit_id", "") or "",
+                            "message": getattr(view_entry, "message", "") or "",
+                            "query": getattr(view_entry, "query", None),
+                            "tql_query": getattr(view_entry, "tql_query", None),
+                        }
+                        st.rerun()
+            with col_del:
+                # Owner-only: the backend would raise UnAuthorizationError for
+                # non-owners anyway; gating here avoids a scary stack trace
+                # during the live demo and makes the rule visually obvious.
+                _can_delete = bool(target_vid) and _is_mine
+                _del_help = None
+                if target_vid and not _is_mine:
+                    _del_help = (
+                        f"View `{target_vid}` is owned by `{_target_owner}`. "
+                        "Only its owner can delete it."
+                    )
+                _confirm_del = st.checkbox(
+                    f"Confirm delete `{target_vid}`" if target_vid else "Confirm delete",
+                    key="qs_view_del_confirm",
+                    disabled=not _can_delete,
+                    help=_del_help,
+                )
+                if st.button("Delete View", key="qs_view_delete",
+                             disabled=not _can_delete, help=_del_help):
+                    if not _confirm_del:
+                        st.warning("Please tick the confirmation box before deleting.")
+                    else:
+                        err = delete_saved_view(ds, target_vid)
+                        if err:
+                            st.error(err)
+                        else:
+                            st.success(f"Deleted view '{target_vid}'.")
+                            st.rerun()
+                if target_vid and not _is_mine:
+                    st.caption(f"🔒 Owned by `{_target_owner}` — read-only to you.")
+
+        st.markdown("---")
+
+        # ── Mode switch: a single unified "Run Query" form ─────────────────
+        mode = st.radio(
+            "Query mode",
+            ["Conditional filter", "Vector search"],
+            key="qs_mode",
+            horizontal=True,
+            help="Pick one approach per run. The two modes share the result "
+            "pane below and the 'Save as view' step.",
+        )
+
+        if mode == "Conditional filter":
             st.subheader("Conditional Filtering")
 
-            # Dynamic condition list tracked by unique IDs
             if "filter_cond_ids" not in st.session_state:
                 st.session_state.filter_cond_ids = [0]
                 st.session_state.filter_next_id = 1
@@ -1033,7 +1198,6 @@ elif page == "🔍 Query & Search":
                                         label_visibility="collapsed" if pos > 0 else "visible")
                 with c_btn:
                     if pos == 0:
-                        # Spacer to align with label row, then ＋ button
                         st.markdown("<div style='height:29px'></div>", unsafe_allow_html=True)
                         if st.button("＋", key="add_cond", help="Add condition"):
                             new_id = st.session_state.filter_next_id
@@ -1047,8 +1211,7 @@ elif page == "🔍 Query & Search":
 
                 conditions.append((field, op, val))
 
-            if st.button("Run Query", type="primary"):
-                # Parse values
+            if st.button("Run Query", type="primary", key="qs_run_filter"):
                 parsed_conds = []
                 for field, op, val in conditions:
                     if op in (">", "<", ">=", "<="):
@@ -1064,46 +1227,358 @@ elif page == "🔍 Query & Search":
                             pass
                     parsed_conds.append((field, op, val))
 
-                # Auto-create inverted index for CONTAINS queries if missing
-                for field, op, val in parsed_conds:
-                    if op == "CONTAINS":
-                        branch = ds.version_state["branch"]
-                        meta_path = f"inverted_index_dir_vec/{branch}/meta.json"
-                        has_index = False
-                        try:
-                            import json as _json
-                            meta = _json.loads(ds.storage[meta_path].decode("utf-8"))
-                            has_index = field in meta
-                        except KeyError:
-                            pass
-                        if not has_index:
-                            with st.spinner(f"Creating inverted index for '{field}'..."):
-                                if ds.has_head_changes:
-                                    ds.commit(message="Auto-commit before index creation")
-                                ds.create_index_vectorized(field)
+                def _idx_progress(field: str) -> None:
+                    st.info(
+                        f"No inverted index found for `{field}` — building it "
+                        "now (one-time cost; reused on later CONTAINS queries)."
+                    )
 
-                result_ds, err = run_query(ds, parsed_conds, connectors if connectors else None)
+                with st.spinner("Running query..."):
+                    result_ds, err = run_query(
+                        ds,
+                        parsed_conds,
+                        connectors if connectors else None,
+                        progress_cb=_idx_progress,
+                    )
                 if err:
                     st.error(err)
                 else:
                     n_results = len(result_ds)
-                    st.success(f"Found {n_results} matching samples")
-                    if n_results > 0:
-                        df, _ = dataset_to_dataframe(result_ds, end=min(n_results, 200))
-                        if df is not None:
-                            st.dataframe(dataframe_for_streamlit_display(df), width="stretch")
+                    st.session_state["qs_result_ds"] = result_ds
+                    st.session_state["qs_result_desc"] = (
+                        f"Conditional filter → {n_results} matching samples"
+                    )
+                    st.session_state["qs_result_meta"] = {
+                        "source": "filter",
+                        "conditions": parsed_conds,
+                        "connectors": list(connectors),
+                    }
 
-        with tab_vector:
+        else:  # Vector search
             st.subheader("Vector Similarity Search")
-            st.info("Vector search requires an embeddings tensor with a vector index.")
-            st.markdown("""
-            **How to use:**
-            1. Create a tensor with `htype='embedding'`
-            2. Build a vector index with `ds.create_index()`
-            3. Query with `ds.query(tensor_name, query_vector)`
 
-            *This feature requires pre-computed embeddings.*
-            """)
+            vec_tensors = list_vector_tensor_names(ds)
+            idx_map = list_vector_indexes(ds)
+
+            if not vec_tensors and not idx_map:
+                st.info(
+                    "No `embedding`/`vector` tensor declared on this dataset. "
+                    "Add one with `htype='embedding'` (float32), populate it, "
+                    "then build an index via `ds.create_vector_index(...)`."
+                )
+            else:
+                # Allow choosing any tensor that *has* an index, even if its
+                # declared htype is not literally 'embedding' — so users with
+                # generic float tensors + an index are not blocked.
+                selectable = sorted(set(vec_tensors) | set(idx_map.keys()))
+                col_t, col_i, col_k = st.columns([2, 2, 1])
+                with col_t:
+                    v_tensor = st.selectbox(
+                        "Embedding tensor", selectable, key="qs_vec_tensor"
+                    )
+                indexes_for_tensor = idx_map.get(v_tensor, [])
+                with col_i:
+                    if indexes_for_tensor:
+                        v_index = st.selectbox(
+                            "Vector index", indexes_for_tensor, key="qs_vec_index"
+                        )
+                    else:
+                        v_index = st.text_input(
+                            "Vector index (will be created)",
+                            value="demo_flat",
+                            key="qs_vec_index_new",
+                            help="No existing index on this tensor; one will be "
+                            "built on the current commit when you run the search.",
+                        )
+                with col_k:
+                    topk = st.number_input(
+                        "top-k", min_value=1, max_value=1000, value=10, step=1,
+                        key="qs_vec_topk",
+                    )
+
+                dim = tensor_embedding_dim(ds, v_tensor)
+                qv_help = (
+                    f"Comma/space-separated floats. Expected dimension: {dim}"
+                    if dim else "Comma/space-separated floats."
+                )
+                qv_text = st.text_area(
+                    "Query vector", key="qs_vec_text", height=100, help=qv_help,
+                    placeholder="e.g. 0.12, -0.03, 0.88, ..." if not dim else
+                    ", ".join(["0.0"] * min(int(dim), 8)) + (", ..." if dim and dim > 8 else ""),
+                )
+
+                col_metric, col_type = st.columns(2)
+                with col_metric:
+                    metric = st.selectbox("Metric", ["l2", "cosine", "ip"], key="qs_vec_metric",
+                                          disabled=bool(indexes_for_tensor),
+                                          help="Ignored when reusing an existing index "
+                                          "(that index was built with its own metric).")
+                with col_type:
+                    index_type = st.selectbox("Index type", ["FLAT", "IVF", "IVFPQ"],
+                                              key="qs_vec_idx_type",
+                                              disabled=bool(indexes_for_tensor),
+                                              help="Used only when creating a new index.")
+
+                if st.button("Run Vector Search", type="primary", key="qs_run_vec"):
+                    qvec, perr = parse_query_vector(qv_text, expected_dim=dim)
+                    if perr:
+                        st.error(perr)
+                    else:
+                        if not indexes_for_tensor:
+                            with st.spinner(
+                                f"Building vector index '{v_index}' on '{v_tensor}'…"
+                            ):
+                                ierr = ensure_vector_index(
+                                    ds, v_tensor, v_index,
+                                    index_type=index_type, metric=metric,
+                                )
+                            if ierr:
+                                st.error(ierr)
+                                st.stop()
+                        with st.spinner("Searching…"):
+                            result_ds, positions, dists, verr = run_vector_search(
+                                ds, v_tensor, v_index, qvec, topk=int(topk),
+                            )
+                        if verr:
+                            st.error(verr)
+                        else:
+                            n_hits = len(result_ds) if result_ds is not None else 0
+                            st.session_state["qs_result_ds"] = result_ds
+                            st.session_state["qs_result_desc"] = (
+                                f"Vector search on `{v_tensor}` (index `{v_index}`, "
+                                f"top-{int(topk)}) → {n_hits} hits"
+                            )
+                            st.session_state["qs_result_meta"] = {
+                                "source": "vector",
+                                "tensor": v_tensor,
+                                "index": v_index,
+                                "topk": int(topk),
+                                "positions": list(positions or []),
+                                "distances": dists.tolist() if dists is not None else [],
+                            }
+
+        # ── Shared result pane ─────────────────────────────────────────────
+        st.markdown("---")
+        result_ds = st.session_state.get("qs_result_ds")
+        result_desc = st.session_state.get("qs_result_desc")
+        result_meta = st.session_state.get("qs_result_meta") or {}
+
+        if result_ds is None:
+            st.caption("No active query result. Run a query above, or load a saved view.")
+        else:
+            n_results = len(result_ds)
+
+            # ── Origin card for loaded views ─────────────────────────────
+            # Views are the collaboration handoff primitive: seeing *who*
+            # created the view and *what question* they asked is what turns
+            # an opaque sample list into actionable context.
+            if result_meta.get("source") == "view":
+                _vid = result_meta.get("view_id", "")
+                _owner = result_meta.get("owner", "-")
+                _is_mine = bool(result_meta.get("is_mine"))
+                _source_commit = (result_meta.get("source_commit") or "")[:8]
+                _msg = result_meta.get("message") or ""
+                _query = result_meta.get("query") or result_meta.get("tql_query") or ""
+
+                if _is_mine:
+                    _owner_badge = f"👤 **you** (`{_owner}`) · editable"
+                else:
+                    _owner_badge = f"🔒 **read-only** · owned by `{_owner}`"
+
+                st.markdown(
+                    f"### 📁 View `{_vid}`  \n{_owner_badge}"
+                )
+                meta_cols = st.columns(3)
+                meta_cols[0].metric("Samples", n_results)
+                meta_cols[1].metric("Source commit", _source_commit or "—")
+                meta_cols[2].metric("Virtual", "yes" if result_meta.get("virtual", True) else "no")
+
+                if _msg:
+                    st.caption(f"**Message:** {_msg}")
+                if _query:
+                    st.markdown("**Original query:**")
+                    st.code(_query, language="text")
+                else:
+                    st.caption(
+                        "_No query string recorded — this view was saved from "
+                        "a programmatic sub-view rather than a filter._"
+                    )
+                st.markdown("")
+            else:
+                st.success(result_desc or f"{n_results} samples in current result")
+
+            # Vector-search hit list
+            if result_meta.get("source") == "vector" and result_meta.get("positions"):
+                pos = result_meta["positions"]
+                dists = result_meta.get("distances", [])
+                if len(dists) == len(pos):
+                    hits_df = pd.DataFrame({
+                        "rank": list(range(1, len(pos) + 1)),
+                        "sample_idx": pos,
+                        "distance": dists,
+                    })
+                else:
+                    hits_df = pd.DataFrame({
+                        "rank": list(range(1, len(pos) + 1)),
+                        "sample_idx": pos,
+                    })
+                with st.expander("Nearest-neighbor hit list", expanded=False):
+                    st.dataframe(hits_df, width="stretch", hide_index=True)
+
+            # ── Image grid inspector ─────────────────────────────────────
+            # Mostly matters for loaded views (engineer wants to visually
+            # confirm what Alice's query produced before reusing it), but we
+            # make it available for any image-bearing result.
+            img_tensors_r = list_image_tensor_names(result_ds) if n_results > 0 else []
+            if img_tensors_r:
+                if not pil_preview_available():
+                    st.info(
+                        "Install **Pillow** (`pip install pillow`) to enable "
+                        "the image grid preview."
+                    )
+                else:
+                    with st.expander("🖼️ Inspect images", expanded=(result_meta.get("source") == "view")):
+                        preview_col = (
+                            img_tensors_r[0]
+                            if len(img_tensors_r) == 1
+                            else st.selectbox(
+                                "Image column", img_tensors_r, key="qs_view_img_col"
+                            )
+                        )
+
+                        # COCO overlay support — only bother auto-detecting on
+                        # datasets that obviously follow that schema.
+                        _is_coco = is_coco2017_muller_schema(result_ds)
+                        _coco_cat_map = None
+                        _coco_overlay = False
+                        if _is_coco:
+                            _coco_overlay = st.checkbox(
+                                "Overlay bounding boxes & labels",
+                                value=True, key="qs_view_coco_overlay",
+                            )
+                            if _coco_overlay:
+                                _ann = st.text_input(
+                                    "COCO instances JSON (for category names)",
+                                    value=DEFAULT_COCO_INSTANCES_JSON,
+                                    key="qs_view_coco_ann",
+                                )
+                                if _ann.strip():
+                                    _coco_cat_map, _cerr = load_coco_category_id_to_name(_ann.strip())
+                                    if _cerr:
+                                        st.warning(_cerr)
+
+                        per_page = 12
+                        total_pages = max(1, (n_results + per_page - 1) // per_page)
+                        grid_page = st.number_input(
+                            "Page", min_value=1, max_value=total_pages, step=1,
+                            key="qs_view_grid_page",
+                        )
+                        lo = (int(grid_page) - 1) * per_page
+                        hi = min(lo + per_page, n_results)
+                        st.caption(
+                            f"Showing samples **{lo + 1}–{hi}** of **{n_results}** · "
+                            f"page **{int(grid_page)}** / **{total_pages}**"
+                        )
+                        try:
+                            _chunk = result_ds[lo:hi]
+                            _raw_imgs = list(_chunk[preview_col].numpy(aslist=True))
+                        except Exception as _e:
+                            st.warning(f"Could not load images: {_e}")
+                            _raw_imgs = []
+
+                        if _raw_imgs:
+                            cols_per_row = 4
+                            for row_start in range(0, len(_raw_imgs), cols_per_row):
+                                row_cells = st.columns(cols_per_row)
+                                for j, cell in enumerate(row_cells):
+                                    k = row_start + j
+                                    if k >= len(_raw_imgs):
+                                        continue
+                                    with cell:
+                                        _pil = decode_muller_image_sample(_raw_imgs[k])
+                                        if _pil is not None and _coco_overlay and _is_coco:
+                                            try:
+                                                _bb = _chunk.bbox[k].numpy(aslist=True)
+                                                _cid = _chunk.category_id[k].numpy(aslist=True)
+                                                _pil = pil_overlay_coco_bboxes(
+                                                    _pil, _bb, _cid, _coco_cat_map
+                                                )
+                                            except Exception:
+                                                pass
+                                        _thumb = (
+                                            pil_square_thumbnail(_pil, 180)
+                                            if _pil is not None else None
+                                        )
+                                        if _thumb is not None:
+                                            st.image(_thumb)
+                                        else:
+                                            st.caption("_(decode failed)_")
+                                        st.caption(f"**#{lo + k}**")
+                                        if _pil is not None and _dm_fullres_dialog is not None:
+                                            _key = f"qs_view_fs_{lo + k}"
+                                            if st.button(
+                                                "Full size", key=_key,
+                                                help="Open at native resolution",
+                                            ):
+                                                st.session_state["dm_fullres_pil"] = _pil.copy()
+                                                st.session_state["dm_fullres_caption"] = (
+                                                    f"Sample index **{lo + k}** (full resolution)"
+                                                )
+                                                _dm_fullres_dialog()
+
+            # Tabular preview
+            if n_results > 0:
+                with st.expander("📊 Table preview", expanded=(not bool(img_tensors_r))):
+                    df, derr = dataset_to_dataframe(result_ds, end=min(n_results, 200))
+                    if derr:
+                        st.error(derr)
+                    elif df is not None:
+                        st.dataframe(dataframe_for_streamlit_display(df), width="stretch")
+
+            # Save as view
+            with st.expander("💾 Save result as view", expanded=False):
+                # Note on semantics: even if the active result came from a
+                # read-only borrow of another engineer's view, saving it here
+                # creates a NEW view owned by the current user (``uid`` comes
+                # from ``obtain_current_user()`` inside MULLER's save_view).
+                # This is the collaboration handoff: "I reuse Alice's query
+                # result as my starting point, and snapshot it as my own view."
+                if result_meta.get("source") == "view" and not result_meta.get("is_mine"):
+                    st.caption(
+                        f"ℹ️ This result was loaded from `{result_meta.get('owner', '-')}`'s view. "
+                        "Saving here creates a **new** view owned by "
+                        f"`{current_user()}`."
+                    )
+                _default_vid = ""
+                if result_meta.get("source") == "view" and result_meta.get("is_mine"):
+                    # Only pre-fill when the active view is already ours —
+                    # otherwise we'd invite the user to stomp on a foreign id.
+                    _default_vid = str(result_meta.get("view_id", ""))
+                new_vid = st.text_input(
+                    "View ID", value=_default_vid, key="qs_save_vid",
+                    help="Required. Letters/numbers/underscore recommended; "
+                    "must be unique within this dataset.",
+                )
+                new_msg = st.text_input(
+                    "Message (optional)", value=result_desc or "",
+                    key="qs_save_msg",
+                )
+                if st.button("Save as View", type="primary", key="qs_save_btn"):
+                    vid_clean = new_vid.strip()
+                    if not vid_clean:
+                        st.error("Please enter a non-empty view ID.")
+                    else:
+                        path, serr = save_query_view(
+                            result_ds, view_id=vid_clean, message=new_msg or None
+                        )
+                        if serr:
+                            st.error(serr)
+                        else:
+                            st.success(
+                                f"Saved view `{vid_clean}` "
+                                f"({n_results} samples). Stored at: `{path}`"
+                            )
+                            st.rerun()
 
 
 # ============================================================================
@@ -1117,201 +1592,232 @@ elif page == "🌿 Version Control":
     else:
         ds = st.session_state.dataset
 
-        tab_branch, tab_merge = st.tabs(["Branches", "Merge & Conflicts"])
-
         # --- Branches ---
-        with tab_branch:
-            st.subheader("Branch Management")
+        st.subheader("Branch Management")
 
-            branches, err = branch_ops(ds, "list")
-            if err:
-                st.error(err)
-                st.stop()
+        branches, err = branch_ops(ds, "list")
+        if err:
+            st.error(err)
+            st.stop()
 
-            branch_names = list(branches.keys()) if isinstance(branches, dict) else branches
+        branch_names = list(branches.keys()) if isinstance(branches, dict) else branches
 
-            if st.button("Refresh", key="refresh_graph"):
-                st.rerun()
+        if st.button("Refresh", key="refresh_graph"):
+            st.rerun()
 
-            # Visual commit graph
-            try:
-                _graph_data = build_commit_graph_data(ds)
-                _graph_h = 22 + _graph_data["lane_count"] * 46 + 20
-                _graph_html = render_commit_graph_html(_graph_data, height=_graph_h)
-                components.html(_graph_html, height=_graph_h, scrolling=False)
-            except Exception:
-                # Fallback to markdown
-                st.markdown("**Current branches:**")
-                for bname in branch_names:
-                    if bname == ds.branch:
-                        st.markdown(f"- **{bname}** ← current")
+        # Visual commit graph
+        try:
+            _graph_data = build_commit_graph_data(ds)
+            _graph_h = 22 + _graph_data["lane_count"] * 46 + 20
+            _graph_html = render_commit_graph_html(_graph_data, height=_graph_h)
+            components.html(_graph_html, height=_graph_h, scrolling=False)
+        except Exception:
+            # Fallback to markdown
+            st.markdown("**Current branches:**")
+            for bname in branch_names:
+                if bname == ds.branch:
+                    st.markdown(f"- **{bname}** ← current")
+                else:
+                    st.markdown(f"- {bname}")
+
+        col_create, col_switch, col_delete = st.columns(3)
+
+        with col_create:
+            st.markdown("**Create Branch**")
+            new_branch = st.text_input("New branch name", key="new_branch")
+            if st.button("Create Branch", type="primary"):
+                if not new_branch:
+                    st.error("Enter a branch name")
+                else:
+                    # Commit pending changes before branching
+                    if ds.has_head_changes:
+                        commit_dataset(ds, "Auto-commit before branch creation")
+                    res, err = branch_ops(ds, "create", branch_name=new_branch)
+                    if err:
+                        st.error(err)
                     else:
-                        st.markdown(f"- {bname}")
+                        st.session_state.current_branch = new_branch
+                        st.success(res)
+                        st.rerun()
 
-            col_create, col_switch = st.columns(2)
+        with col_switch:
+            st.markdown("**Switch Branch**")
+            other_branches = [b for b in branch_names]
+            target = st.selectbox("Target branch", other_branches, key="switch_branch")
+            if st.button("Checkout"):
+                if ds.has_head_changes:
+                    commit_dataset(ds, "Auto-commit before checkout")
+                res, err = branch_ops(ds, "checkout", branch_name=target)
+                if err:
+                    st.error(err)
+                else:
+                    st.session_state.current_branch = target
+                    st.success(res)
+                    st.rerun()
 
-            with col_create:
-                st.markdown("**Create Branch**")
-                new_branch = st.text_input("New branch name", key="new_branch")
-                if st.button("Create Branch", type="primary"):
-                    if not new_branch:
-                        st.error("Enter a branch name")
+        with col_delete:
+            st.markdown("**Delete Branch**")
+            # Pre-compute which branches are actually deletable (mirrors backend rules:
+            # not `main`, not current, no sub-branches, never merged into another branch).
+            deletable_map = classify_deletable_branches(ds)
+            deletable = [b for b in branch_names if deletable_map.get(b) is None]
+            blocked = [(b, deletable_map.get(b)) for b in branch_names
+                       if deletable_map.get(b) is not None]
+
+            if not deletable:
+                st.selectbox("Branch to delete", ["(none)"],
+                             key="delete_branch_none", disabled=True)
+                st.caption("No deletable branches.")
+            else:
+                del_target = st.selectbox("Branch to delete", deletable,
+                                          key="delete_branch_target")
+                confirm_del = st.checkbox(f"Confirm delete `{del_target}`",
+                                          key="confirm_delete_branch")
+                if st.button("Delete Branch"):
+                    if not confirm_del:
+                        st.warning("Please tick the confirmation box before deleting.")
                     else:
-                        # Commit pending changes before branching
-                        if ds.has_head_changes:
-                            commit_dataset(ds, "Auto-commit before branch creation")
-                        res, err = branch_ops(ds, "create", branch_name=new_branch)
+                        res, err = branch_ops(ds, "delete", branch_name=del_target)
                         if err:
                             st.error(err)
                         else:
-                            st.session_state.current_branch = new_branch
                             st.success(res)
                             st.rerun()
 
-            with col_switch:
-                st.markdown("**Switch Branch**")
-                other_branches = [b for b in branch_names]
-                target = st.selectbox("Target branch", other_branches, key="switch_branch")
-                if st.button("Checkout"):
-                    if ds.has_head_changes:
-                        commit_dataset(ds, "Auto-commit before checkout")
-                    res, err = branch_ops(ds, "checkout", branch_name=target)
-                    if err:
-                        st.error(err)
-                    else:
-                        st.session_state.current_branch = target
-                        st.success(res)
-                        st.rerun()
+            if blocked:
+                with st.expander(f"Non-deletable branches ({len(blocked)})", expanded=False):
+                    for bname, reason in blocked:
+                        st.markdown(f"- `{bname}` — _{reason}_")
 
         # --- Merge & Conflicts ---
-        with tab_merge:
-            st.subheader("Merge & Conflict Resolution")
+        st.markdown("---")
+        st.subheader("Merge & Conflict Resolution")
 
-            branches, _ = branch_ops(ds, "list")
-            branch_names = list(branches.keys()) if isinstance(branches, dict) else branches
-            other = [b for b in branch_names if b != ds.branch]
+        branches, _ = branch_ops(ds, "list")
+        branch_names = list(branches.keys()) if isinstance(branches, dict) else branches
+        other = [b for b in branch_names if b != ds.branch]
 
-            if not other:
-                st.info("No other branches to merge.")
-            else:
-                merge_src = st.selectbox("Merge from branch", other, key="merge_src")
+        if not other:
+            st.info("No other branches to merge.")
+        else:
+            merge_src = st.selectbox("Merge from branch", other, key="merge_src")
 
-                # Detect conflicts
-                if st.button("Detect Conflicts"):
-                    result, err = branch_ops(ds, "detect_conflict", branch_name=merge_src)
-                    if err:
-                        st.error(err)
+            # Detect conflicts
+            if st.button("Detect Conflicts"):
+                result, err = branch_ops(ds, "detect_conflict", branch_name=merge_src)
+                if err:
+                    st.error(err)
+                else:
+                    # Check tensor-level conflicts (renames/deletes)
+                    has_tensor_conflicts = bool(result["columns"])
+
+                    # Check sample-level conflicts across ALL common tensors
+                    tensors_with_sample_conflicts = []
+                    for col_name, cdata in result.get("records", {}).items():
+                        has_append = bool(cdata.get("app_ori_idx") and cdata.get("app_tar_idx"))
+                        has_update = False
+                        if cdata.get("update_values"):
+                            uv = cdata["update_values"]
+                            has_update = bool(uv.get("update_ori") or uv.get("update_tar"))
+                        has_delete = bool(cdata.get("del_ori_idx") or cdata.get("del_tar_idx"))
+                        if has_append or has_update or has_delete:
+                            tensors_with_sample_conflicts.append(col_name)
+
+                    if has_tensor_conflicts or tensors_with_sample_conflicts:
+                        conflict_summary = []
+                        if has_tensor_conflicts:
+                            conflict_summary.append(f"Tensor conflicts: {', '.join(result['columns'])}")
+                        if tensors_with_sample_conflicts:
+                            conflict_summary.append(f"Sample conflicts in: {', '.join(tensors_with_sample_conflicts)}")
+                        st.warning(" | ".join(conflict_summary))
+
+                        # Show details for all tensors that have any conflict
+                        all_conflict_tensors = set(tensors_with_sample_conflicts)
+                        if has_tensor_conflicts:
+                            all_conflict_tensors.update(result["columns"])
+
+                        with st.expander("Conflict Details", expanded=True):
+                            for col_name in sorted(all_conflict_tensors):
+                                st.markdown(f"#### `{col_name}`")
+                                cdata = result["records"].get(col_name, {})
+
+                                # Append conflicts (both branches appended)
+                                if cdata.get("app_ori_idx") and cdata.get("app_tar_idx"):
+                                    st.markdown("**Append conflicts (both branches added samples):**")
+                                    rows = []
+                                    ori_vals = cdata.get("app_ori_values", [])
+                                    tar_vals = cdata.get("app_tar_values", [])
+                                    for j, idx in enumerate(cdata["app_ori_idx"]):
+                                        rows.append({"Side": "Current (ours)", "Index": idx,
+                                                     "Value": str(ori_vals[j]) if j < len(ori_vals) else "—"})
+                                    for j, idx in enumerate(cdata["app_tar_idx"]):
+                                        rows.append({"Side": "Source (theirs)", "Index": idx,
+                                                     "Value": str(tar_vals[j]) if j < len(tar_vals) else "—"})
+                                    if rows:
+                                        st.dataframe(pd.DataFrame(rows), width="stretch")
+                                elif cdata.get("app_ori_idx"):
+                                    st.markdown(f"**Appended in current only:** {len(cdata['app_ori_idx'])} samples")
+                                elif cdata.get("app_tar_idx"):
+                                    st.markdown(f"**Appended in source only:** {len(cdata['app_tar_idx'])} samples")
+
+                                # Update conflicts
+                                if cdata.get("update_values"):
+                                    update_ori = cdata["update_values"].get("update_ori", [])
+                                    update_tar = cdata["update_values"].get("update_tar", [])
+                                    if update_ori or update_tar:
+                                        st.markdown("**Update conflicts:**")
+                                        comp = []
+                                        all_idx = set()
+                                        for d in update_ori:
+                                            all_idx.update(d.keys())
+                                        for d in update_tar:
+                                            all_idx.update(d.keys())
+                                        for idx in sorted(all_idx):
+                                            ov = next((d[idx] for d in update_ori if idx in d), "—")
+                                            tv = next((d[idx] for d in update_tar if idx in d), "—")
+                                            comp.append({"Index": idx, "Current (ours)": str(ov), "Source (theirs)": str(tv)})
+                                        if comp:
+                                            cdf = pd.DataFrame(comp)
+
+                                            def _hl(row):
+                                                if row["Current (ours)"] != "—" and row["Source (theirs)"] != "—":
+                                                    return ["background-color: #ffcccc"] * len(row)
+                                                return [""] * len(row)
+
+                                            st.dataframe(cdf.style.apply(_hl, axis=1), width="stretch")
+
+                                # Delete conflicts
+                                if cdata.get("del_ori_idx") or cdata.get("del_tar_idx"):
+                                    st.markdown("**Delete conflicts:**")
+                                    if cdata.get("del_ori_idx"):
+                                        st.markdown(f"- Current deletes: {cdata['del_ori_idx']}")
+                                    if cdata.get("del_tar_idx"):
+                                        st.markdown(f"- Source deletes: {cdata['del_tar_idx']}")
                     else:
-                        # Check tensor-level conflicts (renames/deletes)
-                        has_tensor_conflicts = bool(result["columns"])
+                        st.success("No conflicts detected — safe to merge.")
 
-                        # Check sample-level conflicts across ALL common tensors
-                        tensors_with_sample_conflicts = []
-                        for col_name, cdata in result.get("records", {}).items():
-                            has_append = bool(cdata.get("app_ori_idx") and cdata.get("app_tar_idx"))
-                            has_update = False
-                            if cdata.get("update_values"):
-                                uv = cdata["update_values"]
-                                has_update = bool(uv.get("update_ori") or uv.get("update_tar"))
-                            has_delete = bool(cdata.get("del_ori_idx") or cdata.get("del_tar_idx"))
-                            if has_append or has_update or has_delete:
-                                tensors_with_sample_conflicts.append(col_name)
+            st.markdown("---")
+            st.markdown("**Merge Strategy**")
+            c1, c2, c3 = st.columns(3)
+            with c1:
+                append_res = st.radio("Append", ["ours", "theirs", "both"], key="m_app")
+            with c2:
+                pop_res = st.radio("Delete", ["ours", "theirs"], key="m_pop")
+            with c3:
+                update_res = st.radio("Update", ["ours", "theirs"], key="m_upd")
 
-                        if has_tensor_conflicts or tensors_with_sample_conflicts:
-                            conflict_summary = []
-                            if has_tensor_conflicts:
-                                conflict_summary.append(f"Tensor conflicts: {', '.join(result['columns'])}")
-                            if tensors_with_sample_conflicts:
-                                conflict_summary.append(f"Sample conflicts in: {', '.join(tensors_with_sample_conflicts)}")
-                            st.warning(" | ".join(conflict_summary))
-
-                            # Show details for all tensors that have any conflict
-                            all_conflict_tensors = set(tensors_with_sample_conflicts)
-                            if has_tensor_conflicts:
-                                all_conflict_tensors.update(result["columns"])
-
-                            with st.expander("Conflict Details", expanded=True):
-                                for col_name in sorted(all_conflict_tensors):
-                                    st.markdown(f"#### `{col_name}`")
-                                    cdata = result["records"].get(col_name, {})
-
-                                    # Append conflicts (both branches appended)
-                                    if cdata.get("app_ori_idx") and cdata.get("app_tar_idx"):
-                                        st.markdown("**Append conflicts (both branches added samples):**")
-                                        rows = []
-                                        ori_vals = cdata.get("app_ori_values", [])
-                                        tar_vals = cdata.get("app_tar_values", [])
-                                        for j, idx in enumerate(cdata["app_ori_idx"]):
-                                            rows.append({"Side": "Current (ours)", "Index": idx,
-                                                         "Value": str(ori_vals[j]) if j < len(ori_vals) else "—"})
-                                        for j, idx in enumerate(cdata["app_tar_idx"]):
-                                            rows.append({"Side": "Source (theirs)", "Index": idx,
-                                                         "Value": str(tar_vals[j]) if j < len(tar_vals) else "—"})
-                                        if rows:
-                                            st.dataframe(pd.DataFrame(rows), width="stretch")
-                                    elif cdata.get("app_ori_idx"):
-                                        st.markdown(f"**Appended in current only:** {len(cdata['app_ori_idx'])} samples")
-                                    elif cdata.get("app_tar_idx"):
-                                        st.markdown(f"**Appended in source only:** {len(cdata['app_tar_idx'])} samples")
-
-                                    # Update conflicts
-                                    if cdata.get("update_values"):
-                                        update_ori = cdata["update_values"].get("update_ori", [])
-                                        update_tar = cdata["update_values"].get("update_tar", [])
-                                        if update_ori or update_tar:
-                                            st.markdown("**Update conflicts:**")
-                                            comp = []
-                                            all_idx = set()
-                                            for d in update_ori:
-                                                all_idx.update(d.keys())
-                                            for d in update_tar:
-                                                all_idx.update(d.keys())
-                                            for idx in sorted(all_idx):
-                                                ov = next((d[idx] for d in update_ori if idx in d), "—")
-                                                tv = next((d[idx] for d in update_tar if idx in d), "—")
-                                                comp.append({"Index": idx, "Current (ours)": str(ov), "Source (theirs)": str(tv)})
-                                            if comp:
-                                                cdf = pd.DataFrame(comp)
-
-                                                def _hl(row):
-                                                    if row["Current (ours)"] != "—" and row["Source (theirs)"] != "—":
-                                                        return ["background-color: #ffcccc"] * len(row)
-                                                    return [""] * len(row)
-
-                                                st.dataframe(cdf.style.apply(_hl, axis=1), width="stretch")
-
-                                    # Delete conflicts
-                                    if cdata.get("del_ori_idx") or cdata.get("del_tar_idx"):
-                                        st.markdown("**Delete conflicts:**")
-                                        if cdata.get("del_ori_idx"):
-                                            st.markdown(f"- Current deletes: {cdata['del_ori_idx']}")
-                                        if cdata.get("del_tar_idx"):
-                                            st.markdown(f"- Source deletes: {cdata['del_tar_idx']}")
-                        else:
-                            st.success("No conflicts detected — safe to merge.")
-
-                st.markdown("---")
-                st.markdown("**Merge Strategy**")
-                c1, c2, c3 = st.columns(3)
-                with c1:
-                    append_res = st.radio("Append", ["ours", "theirs", "both"], key="m_app")
-                with c2:
-                    pop_res = st.radio("Delete", ["ours", "theirs"], key="m_pop")
-                with c3:
-                    update_res = st.radio("Update", ["ours", "theirs"], key="m_upd")
-
-                if st.button("Merge", type="primary"):
-                    strategy = {
-                        "append_resolution": append_res,
-                        "pop_resolution": pop_res,
-                        "update_resolution": update_res,
-                    }
-                    res, err = branch_ops(ds, "merge", branch_name=merge_src, merge_strategy=strategy)
-                    if err:
-                        st.error(err)
-                    else:
-                        st.success(res)
-                        st.rerun()
+            if st.button("Merge", type="primary"):
+                strategy = {
+                    "append_resolution": append_res,
+                    "pop_resolution": pop_res,
+                    "update_resolution": update_res,
+                }
+                res, err = branch_ops(ds, "merge", branch_name=merge_src, merge_strategy=strategy)
+                if err:
+                    st.error(err)
+                else:
+                    st.success(res)
+                    st.rerun()
 
 
 

--- a/streamlit_ui/utils.py
+++ b/streamlit_ui/utils.py
@@ -13,11 +13,111 @@ import muller
 import pandas as pd
 import numpy as np
 from pathlib import Path
-from typing import Optional, List, Tuple, Dict, Any
+from typing import Optional, List, Tuple, Dict, Any, Callable
+import json
 import time
 import os
 import io
+import multiprocessing as _real_multiprocessing
+from multiprocessing.pool import ThreadPool as _ThreadPool
 import plotly.graph_objects as go
+
+from muller.util.exceptions import InvertedIndexNotExistsError, LockedException
+from muller.util.sensitive_config import SensitiveConfig
+from muller.core.auth.authorization import obtain_current_user as _obtain_current_user
+
+
+# ---------------------------------------------------------------------------
+# Current-user helpers (used by UI for multi-user demo + permission gating)
+# ---------------------------------------------------------------------------
+
+
+def current_user() -> str:
+    """Return MULLER's current process-global user (``SensitiveConfig().uid``).
+
+    This is the identity all permission checks (branch ownership, view
+    ownership, etc.) compare against. Default is ``"public"``.
+    """
+    try:
+        return _obtain_current_user() or "public"
+    except Exception:
+        return "public"
+
+
+def set_current_user(uid: str) -> str:
+    """Set the MULLER process-global current user.
+
+    Returns the value actually stored (falls back to ``"public"`` on empty).
+    Streamlit uses this to impersonate different engineers during the demo.
+    Because ``SensitiveConfig`` is a singleton tied to the Python process,
+    this affects every subsequent MULLER call in the same Streamlit session
+    (which is exactly what we want for multi-user storytelling).
+    """
+    value = (uid or "").strip() or "public"
+    try:
+        SensitiveConfig().uid = value
+    except Exception:
+        pass
+    return value
+
+
+# ---------------------------------------------------------------------------
+# MULLER process-pool compatibility shim for Streamlit (and any other host
+# whose __main__ is not importable, or whose process is multi-threaded).
+#
+# ``create_index_vectorized`` and ``optimize_index`` fan out their per-batch /
+# per-shard work through ``multiprocessing.Pool(...).apply_async(...)`` and
+# then ``pool.close(); pool.join()`` — they never call ``.get()`` on the
+# futures. Under macOS/Py3.8+ the default start method is ``spawn``, which
+# re-imports ``__main__`` in each worker; when running under ``streamlit run``
+# that ``__main__`` resolves to ``streamlit.web.cli`` (not our script), and the
+# worker either boot-loops Streamlit or dies before running ``_process_index``.
+# Either way no batch completion markers get written, ``check_index_completeness``
+# returns "unfinished", ``create_index`` returns False, ``_create_new_index``
+# only emits ``warnings.warn("Create index fails.")``, and meta.json is never
+# updated — the exact symptom our users hit ("did not complete").
+#
+# Switching to ``multiprocessing.pool.ThreadPool`` sidesteps the issue: threads
+# share the parent's address space (no pickling, no re-import of __main__), the
+# MULLER workers' Python-level tokenization plus storage writes are mostly
+# GIL-releasing I/O, and the indexing volumes in a demo UI are trivially small.
+# ---------------------------------------------------------------------------
+
+
+def _MullerThreadPoolShim(*args, **kwargs):
+    """Drop-in for ``multiprocessing.Pool`` that runs tasks in threads.
+
+    ``multiprocessing.Pool`` accepts ``maxtasksperchild``, which
+    ``ThreadPool`` does not; strip it so callers that pass it through
+    (MULLER does) don't blow up with ``TypeError``.
+    """
+    kwargs.pop("maxtasksperchild", None)
+    return _ThreadPool(*args, **kwargs)
+
+
+def _install_muller_pool_shim() -> None:
+    """Idempotently replace ``multiprocessing`` inside MULLER's index module.
+
+    We only touch the attribute lookup used inside
+    ``muller.core.query.inverted_index_vectorized`` — everything else in
+    MULLER continues to use the stdlib's real ``multiprocessing``.
+    """
+    from muller.core.query import inverted_index_vectorized as _iiv_mod
+
+    if getattr(_iiv_mod.multiprocessing, "_is_muller_ui_shim", False):
+        return
+
+    class _ShimModule:
+        _is_muller_ui_shim = True
+        Pool = staticmethod(_MullerThreadPoolShim)
+
+        def __getattr__(self, name):
+            return getattr(_real_multiprocessing, name)
+
+    _iiv_mod.multiprocessing = _ShimModule()
+
+
+_install_muller_pool_shim()
 
 try:
     from PIL import Image as PILImage
@@ -388,18 +488,152 @@ def delete_sample(ds: Any, index: int) -> Optional[str]:
         return f"Failed to delete sample: {e}"
 
 
+def _inverted_index_has_field(ds: Any, tensor_column: str) -> bool:
+    """Return True iff ``inverted_index_dir_vec/<branch>/meta.json`` has an
+    entry for ``tensor_column`` (the source of truth used by
+    ``filter_vectorized`` to decide whether an index exists)."""
+    branch = ds.version_state.get("branch", "main")
+    meta_path = os.path.join("inverted_index_dir_vec", branch, "meta.json")
+    try:
+        raw = ds.storage[meta_path]
+    except Exception:
+        return False
+    try:
+        meta = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
+    except Exception:
+        return False
+    return isinstance(meta, dict) and tensor_column in meta
+
+
+def _try_make_writable(ds: Any) -> bool:
+    """Best-effort upgrade of a read-only Dataset to writable.
+
+    Returns True iff the dataset is writable after this call. Swallows the
+    LockedException that ``set_read_only(False, err=True)`` raises when the
+    write-lock is held elsewhere, so the caller can react with a clean error
+    message.
+    """
+    if not getattr(ds, "read_only", False):
+        return True
+    try:
+        ds.set_read_only(False, err=True)
+    except LockedException:
+        return False
+    except Exception:
+        return False
+    return not getattr(ds, "read_only", False)
+
+
+def ensure_inverted_index(
+    ds: Any,
+    tensor_column: str,
+    progress_cb: Optional[Callable[[str], None]] = None,
+) -> Optional[str]:
+    """Make sure a vectorized inverted index exists for ``tensor_column``.
+
+    - No-op if an entry already exists in the meta.json.
+    - Requires a writable dataset: ``create_index_vectorized`` spawns worker
+      subprocesses that write shard files through ``ds.storage[...] = ...``;
+      if the storage is read-only those writes raise ``ReadOnlyModeError``,
+      which ``_process_index`` catches and logs but does **not** re-raise, so
+      the top-level call appears to succeed while meta.json is never written.
+      We detect this up-front and report a clear, actionable error.
+    - Auto-commits pending changes first, because ``create_index_vectorized``
+      silently skips (only ``warnings.warn``) when ``ds.has_head_changes`` is True.
+    - Verifies via meta.json that the index was actually written, so any other
+      silent failure (empty tensor, unsupported htype, worker crash) surfaces
+      as an error string instead of pretending success.
+
+    Returns ``None`` on success; returns an error string on failure.
+    """
+    if _inverted_index_has_field(ds, tensor_column):
+        return None
+
+    if getattr(ds, "read_only", False) and not _try_make_writable(ds):
+        return (
+            f"Cannot create inverted index for '{tensor_column}': the dataset "
+            "is loaded in read-only mode (its write lock is held by another "
+            "MULLER process or a stale session). Please close any other "
+            "process that has this dataset open and re-load it here."
+        )
+
+    try:
+        if progress_cb is not None:
+            progress_cb(tensor_column)
+        if ds.has_head_changes:
+            ds.commit(message=f"Auto-commit before inverted index for '{tensor_column}'")
+        ds.create_index_vectorized(tensor_column)
+    except Exception as e:
+        return f"Failed to create inverted index for '{tensor_column}': {e}"
+
+    if not _inverted_index_has_field(ds, tensor_column):
+        return (
+            f"Inverted index creation for '{tensor_column}' did not complete "
+            "(no entry recorded in meta.json). Most common causes: (a) the "
+            "tensor is empty, (b) its htype/dtype is unsupported — CONTAINS "
+            "indexing requires htype `text`/`class_label` or dtype `int64`/"
+            "`float64`, (c) the dataset is read-only (check `ds.read_only`)."
+        )
+    return None
+
+
 def run_query(ds: Any, conditions: List[Tuple[str, str, Any]],
               connectors: Optional[List[str]] = None,
-              offset: int = 0, limit: Optional[int] = None) -> Tuple[Optional[Any], Optional[str]]:
-    """Run a filter query on the dataset."""
-    try:
-        kwargs = {"offset": offset, "limit": limit}
-        if connectors:
-            kwargs["connector_list"] = connectors
-        result = ds.filter_vectorized(conditions, **kwargs)
-        return result, None
-    except Exception as e:
-        return None, f"Query failed: {e}"
+              offset: int = 0, limit: Optional[int] = None,
+              auto_create_index: bool = True,
+              progress_cb: Optional[Callable[[str], None]] = None,
+              ) -> Tuple[Optional[Any], Optional[str]]:
+    """Run a filter query on the dataset.
+
+    When ``auto_create_index`` is True (default), a failure caused by a missing
+    inverted index on a ``CONTAINS`` field is transparently recovered by
+    building the index for that field and retrying the query. ``progress_cb``
+    is invoked as ``progress_cb(field_name)`` once per field just before its
+    index is built, so the caller can render progress.
+    """
+    kwargs = {"offset": offset, "limit": limit}
+    if connectors:
+        kwargs["connector_list"] = connectors
+
+    contains_fields = [c[0] for c in conditions if len(c) >= 2 and c[1] == "CONTAINS"]
+    handled: set = set()
+    # One retry per CONTAINS field (plus one slack) is enough: each retry
+    # clears exactly one missing index, and the loop exits as soon as
+    # filter_vectorized stops raising InvertedIndexNotExistsError.
+    max_attempts = len(contains_fields) + 2
+
+    for _ in range(max_attempts):
+        try:
+            result = ds.filter_vectorized(conditions, **kwargs)
+            return result, None
+        except InvertedIndexNotExistsError as e:
+            if not auto_create_index:
+                return None, f"Query failed: {e}"
+            # Find the next CONTAINS field that is missing from meta.json and
+            # that we have not already attempted. Prefer the tensor named in
+            # the exception message when available, to match the backend's view.
+            err_text = str(e)
+            ordered_candidates = sorted(
+                contains_fields,
+                key=lambda f: (f not in err_text, contains_fields.index(f)),
+            )
+            target = None
+            for field in ordered_candidates:
+                if field in handled:
+                    continue
+                if not _inverted_index_has_field(ds, field):
+                    target = field
+                    break
+            if target is None:
+                return None, f"Query failed: {e}"
+            handled.add(target)
+            build_err = ensure_inverted_index(ds, target, progress_cb=progress_cb)
+            if build_err:
+                return None, build_err
+        except Exception as e:
+            return None, f"Query failed: {e}"
+
+    return None, "Query failed: exceeded retry budget while auto-building inverted indexes."
 
 
 def dataset_to_dataframe(ds: Any, tensor_list: Optional[List[str]] = None,
@@ -489,6 +723,10 @@ def branch_ops(ds: Any, action: str, branch_name: Optional[str] = None,
             ds.checkout(branch_name)
             return f"Switched to branch '{branch_name}'", None
 
+        elif action == "delete":
+            ds.delete_branch(branch_name)
+            return f"Branch '{branch_name}' deleted", None
+
         elif action == "merge":
             strategy = merge_strategy or {}
             ds.merge(
@@ -522,6 +760,81 @@ def branch_ops(ds: Any, action: str, branch_name: Optional[str] = None,
 
     except Exception as e:
         return None, f"Branch operation failed: {e}"
+
+
+def classify_deletable_branches(ds: Any) -> Dict[str, Optional[str]]:
+    """For each branch, return None if deletable, else a short reason string.
+
+    Mirrors the constraints of ``muller.core.version_control.delete_branch``:
+      - cannot delete ``main``
+      - cannot delete the currently checked out branch
+      - cannot delete a branch that has sub-branches
+      - cannot delete a branch that has been merged into another branch
+
+    Returns a dict mapping branch_name -> reason (or None if deletable).
+    """
+    result: Dict[str, Optional[str]] = {}
+    try:
+        version_state = ds.version_state
+        commit_node_map = version_state.get("commit_node_map", {}) or {}
+        branch_commit_map = version_state.get("branch_commit_map", {}) or {}
+        current_branch = version_state.get("branch")
+    except Exception as e:
+        return {b: f"unavailable ({e})" for b in (ds.branches if hasattr(ds, "branches") else [])}
+
+    for bname in branch_commit_map.keys():
+        if bname == "main":
+            result[bname] = "cannot delete `main`"
+            continue
+        if bname == current_branch:
+            result[bname] = "currently checked out"
+            continue
+
+        head_id = branch_commit_map.get(bname)
+        head_node = commit_node_map.get(head_id) if head_id else None
+        if head_node is None:
+            # Branch pointer with no commit info — let backend decide; mark deletable.
+            result[bname] = None
+            continue
+
+        # Walk up parent chain while still on this branch; collect commit_ids.
+        all_commits = set()
+        has_subbranch = False
+        cur = head_node
+        try:
+            while cur is not None and getattr(cur, "branch", None) == bname:
+                all_commits.add(cur.commit_id)
+                for child in getattr(cur, "children", []) or []:
+                    if getattr(child, "commit_id", None) not in all_commits:
+                        has_subbranch = True
+                        break
+                if has_subbranch:
+                    break
+                cur = getattr(cur, "parent", None)
+        except Exception as e:
+            result[bname] = f"introspection failed ({e})"
+            continue
+
+        if has_subbranch:
+            result[bname] = "has sub-branches"
+            continue
+
+        # Has any other commit ever merged from this branch?
+        merged = False
+        for cid, node in commit_node_map.items():
+            if cid in all_commits:
+                continue
+            mp = getattr(node, "merge_parent", None)
+            if not mp:
+                continue
+            mp_id = mp if isinstance(mp, str) else getattr(mp, "commit_id", None)
+            if mp_id in all_commits:
+                merged = True
+                break
+
+        result[bname] = "already merged into another branch" if merged else None
+
+    return result
 
 
 def build_commit_graph_data(ds: Any) -> Dict[str, Any]:
@@ -1008,13 +1321,66 @@ def benchmark_parquet_vs_muller(ds: Any, query_conditions: List[Tuple[str, str, 
         return None, f"Benchmark failed: {e}"
 
 
-def load_dataset(path: str) -> Tuple[Optional[Any], Optional[str]]:
-    """Load an existing MULLER dataset."""
+def release_dataset_lock(ds: Any) -> None:
+    """Best-effort release of any write lock held by ``ds``.
+
+    Used before loading a new dataset into the same Streamlit session, so the
+    about-to-be-replaced ``ds`` does not block the new load from obtaining the
+    write lock on the same (or a previously held) path.
+    """
+    if ds is None:
+        return
+    try:
+        if not getattr(ds, "read_only", True):
+            ds.set_read_only(True, err=False)
+    except Exception:
+        pass
+
+
+def load_dataset(
+    path: str,
+    prefer_writable: bool = True,
+) -> Tuple[Optional[Any], Optional[str], Optional[str]]:
+    """Load an existing MULLER dataset.
+
+    Returns ``(ds, error, warning)``:
+    - On success with a writable session: ``warning`` is ``None``.
+    - On success with a read-only fallback (write lock unavailable): ``warning``
+      explains the limitation so the caller can surface it in the UI.
+    - On failure: ``(None, error, None)``.
+
+    Why ``prefer_writable=True`` by default:
+    Several operations the UI exposes (``create_index_vectorized`` in
+    particular) silently do nothing when the storage is read-only, because the
+    worker subprocesses swallow ``ReadOnlyModeError`` deep inside the library.
+    We therefore try to open writable first and only fall back to read-only
+    when the write lock really cannot be acquired, surfacing a clear warning.
+    """
+    if prefer_writable:
+        try:
+            ds = muller.load(path, read_only=False)
+            return ds, None, None
+        except LockedException:
+            pass
+        except Exception as e:
+            return None, f"Failed to load dataset: {e}", None
+
+        try:
+            ds = muller.load(path, read_only=True)
+        except Exception as e:
+            return None, f"Failed to load dataset: {e}", None
+        return ds, None, (
+            "Loaded in **read-only** mode: the dataset's write lock is held "
+            "elsewhere (another process, or a previous Streamlit session that "
+            "did not shut down cleanly). Writes, commits, and inverted-index "
+            "creation will be rejected. Close the other holder and reload."
+        )
+
     try:
         ds = muller.load(path)
-        return ds, None
     except Exception as e:
-        return None, f"Failed to load dataset: {e}"
+        return None, f"Failed to load dataset: {e}", None
+    return ds, None, None
 
 
 def commit_dataset(ds: Any, message: str = "Commit from Streamlit UI") -> Tuple[Optional[str], Optional[str]]:
@@ -1024,6 +1390,322 @@ def commit_dataset(ds: Any, message: str = "Commit from Streamlit UI") -> Tuple[
         return cid, None
     except Exception as e:
         return None, f"Commit failed: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Vector search helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_vector_like_htype(ht: Any) -> bool:
+    if ht is None:
+        return False
+    h = str(ht).lower()
+    return h in ("embedding", "vector")
+
+
+def list_vector_tensor_names(ds: Any) -> List[str]:
+    """Tensor names that can be used as vector-search targets.
+
+    Returns tensors whose declared ``htype`` is ``embedding``/``vector``, plus
+    any 1-D float tensor that *could* be treated as an embedding column.
+    The first group is preferred; callers may display them distinctly.
+    """
+    names: List[str] = []
+    for n, t in ds.tensors.items():
+        if _is_vector_like_htype(t.htype):
+            names.append(n)
+    return names
+
+
+def list_vector_indexes(ds: Any) -> Dict[str, List[str]]:
+    """List vector indexes already built for the dataset on the current branch.
+
+    The vector-index layout (see ``TensorVectorIndex._init_tensor_index``):
+        <ds.path>/_vector_index/<branch>/<tensor_key>/<index_name>/
+
+    Returns ``{tensor_name: [index_name, ...]}``. Empty dict if the
+    ``_vector_index`` directory does not exist yet.
+    """
+    out: Dict[str, List[str]] = {}
+    try:
+        base = Path(ds.path) / "_vector_index" / ds.branch
+    except Exception:
+        return out
+    if not base.exists() or not base.is_dir():
+        return out
+    try:
+        for tdir in base.iterdir():
+            if not tdir.is_dir():
+                continue
+            idx_names = [p.name for p in tdir.iterdir() if p.is_dir()]
+            if idx_names:
+                out[tdir.name] = sorted(idx_names)
+    except Exception:
+        pass
+    return out
+
+
+def parse_query_vector(text: str, expected_dim: Optional[int] = None) -> Tuple[Optional[np.ndarray], Optional[str]]:
+    """Parse comma/space/newline-separated floats into a 1-D float32 vector.
+
+    Returns ``(vector, error)``. If ``expected_dim`` is given, mismatched
+    length becomes an error instead of silent padding/truncation.
+    """
+    if text is None:
+        return None, "Empty query vector."
+    cleaned = text.strip().replace("\n", ",").replace("\t", ",")
+    if not cleaned:
+        return None, "Empty query vector."
+    # Allow either JSON-style "[1, 2, 3]" or plain "1 2 3" / "1,2,3".
+    if cleaned.startswith("[") and cleaned.endswith("]"):
+        cleaned = cleaned[1:-1]
+    parts = [p.strip() for p in cleaned.replace(" ", ",").split(",") if p.strip()]
+    if not parts:
+        return None, "Empty query vector."
+    try:
+        vec = np.array([float(p) for p in parts], dtype=np.float32)
+    except ValueError as e:
+        return None, f"Could not parse as floats: {e}"
+    if expected_dim is not None and vec.shape[0] != expected_dim:
+        return None, (
+            f"Dimension mismatch: got {vec.shape[0]} values, "
+            f"but tensor expects {expected_dim}."
+        )
+    return vec, None
+
+
+def tensor_embedding_dim(ds: Any, tensor_name: str) -> Optional[int]:
+    """Best-effort embedding dimension for ``tensor_name`` (for input validation)."""
+    try:
+        t = ds.tensors.get(tensor_name)
+        if t is None:
+            return None
+        shp = getattr(t, "shape", None)
+        if shp is None and hasattr(t, "shape_interval"):
+            shp = t.shape_interval  # may be an interval
+        try:
+            shp = tuple(shp)
+        except Exception:
+            return None
+        if len(shp) >= 2 and isinstance(shp[-1], (int, np.integer)) and shp[-1] > 0:
+            return int(shp[-1])
+    except Exception:
+        pass
+    return None
+
+
+def _uuids_to_positions(ds: Any, tensor_name: str, uuids: Any) -> List[int]:
+    """Map sample-uuid results from FAISS back to positional row indexes."""
+    t = ds.tensors.get(tensor_name)
+    if t is None:
+        return []
+    try:
+        all_uuids = t._sample_id_tensor.numpy().flatten()
+    except Exception:
+        return []
+    arr = np.asarray(uuids).reshape(-1)
+    positions: List[int] = []
+    for uid in arr:
+        try:
+            hit = np.where(all_uuids == uid)[0]
+            if hit.size:
+                positions.append(int(hit[0]))
+        except Exception:
+            continue
+    return positions
+
+
+def run_vector_search(
+    ds: Any,
+    tensor_name: str,
+    index_name: str,
+    query_vector: np.ndarray,
+    topk: int = 10,
+) -> Tuple[Optional[Any], Optional[List[int]], Optional[np.ndarray], Optional[str]]:
+    """Run KNN search against a pre-built vector index.
+
+    Returns ``(result_ds, positions, distances, error)``.
+    - ``result_ds``: a sub-dataset view of ``ds`` containing the top-k hits
+      (ordered by returned position, not re-sorted by distance — callers that
+      need a "closest first" ordering should use ``positions``+``distances``
+      directly).
+    - ``positions``: the 0-based row indexes in ``ds`` (monotonic after uuid→pos
+      lookup) so the view can be re-computed later / saved as a view.
+    - ``distances``: the raw FAISS distance array aligned with the uuids the
+      index returned, for display only.
+    """
+    try:
+        try:
+            ds.load_vector_index(tensor_name, index_name)
+        except Exception as e:
+            return None, None, None, (
+                f"Failed to load vector index '{index_name}' on "
+                f"'{tensor_name}': {e}"
+            )
+        qv = np.asarray(query_vector, dtype=np.float32).reshape(1, -1)
+        dist, ids = ds.vector_search(qv, tensor_name, index_name, topk=topk)
+        dist_arr = np.asarray(dist).reshape(-1)
+        id_arr = np.asarray(ids).reshape(-1)
+        # Drop FAISS sentinel values for "no neighbour" (-1).
+        keep = id_arr != -1
+        id_arr = id_arr[keep]
+        dist_arr = dist_arr[keep] if dist_arr.shape[0] == keep.shape[0] else dist_arr
+        positions = _uuids_to_positions(ds, tensor_name, id_arr)
+        if not positions:
+            # Fall back to interpreting ids as positional indexes (some index
+            # backends might already return positions).
+            try:
+                maybe_pos = [int(x) for x in id_arr.tolist() if 0 <= int(x) < len(ds)]
+                if maybe_pos:
+                    positions = maybe_pos
+            except Exception:
+                pass
+        if not positions:
+            return None, [], dist_arr, (
+                "Vector search returned 0 hits (or IDs could not be resolved "
+                "to dataset rows). Try a different query vector, or rebuild "
+                "the index on the current branch."
+            )
+        # ``ds[positions]`` gives us a sub-view we can display + save as a view.
+        result_ds = ds[sorted(positions)]
+        return result_ds, positions, dist_arr, None
+    except Exception as e:
+        return None, None, None, f"Vector search failed: {e}"
+
+
+def ensure_vector_index(
+    ds: Any,
+    tensor_name: str,
+    index_name: str,
+    index_type: str = "FLAT",
+    metric: str = "l2",
+) -> Optional[str]:
+    """Create a vector index on-the-fly if it does not exist yet.
+
+    Returns ``None`` on success, or an error string. Auto-commits pending
+    changes first (``create_vector_index`` silently skips when
+    ``ds.has_head_changes``).
+    """
+    _existing = list_vector_indexes(ds)
+    if index_name in _existing.get(tensor_name, []):
+        return None
+    if getattr(ds, "read_only", False) and not _try_make_writable(ds):
+        return (
+            f"Cannot create vector index '{index_name}' on '{tensor_name}': "
+            "dataset is read-only."
+        )
+    try:
+        if ds.has_head_changes:
+            ds.commit(message=f"Auto-commit before building vector index '{index_name}'")
+        ds.create_vector_index(tensor_name, index_name, index_type=index_type, metric=metric)
+    except Exception as e:
+        return f"Failed to create vector index: {e}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Saved-view helpers
+# ---------------------------------------------------------------------------
+
+
+def save_query_view(
+    ds_or_view: Any,
+    view_id: str,
+    message: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Persist a sub-dataset / filtered view into the parent dataset's
+    ``.queries/`` store under a user-chosen ``view_id``.
+
+    ``ds_or_view`` is expected to be either the parent dataset or a sub-view
+    returned by ``filter_vectorized`` / ``ds[positions]``. Both expose
+    ``save_view(view_id=...)`` and persist the view inside the *source*
+    dataset's storage.
+
+    Returns ``(vds_path, error)``. Typical errors: empty ``view_id``, uncommitted
+    parent, duplicate id, read-only dataset.
+    """
+    vid = (view_id or "").strip()
+    if not vid:
+        return None, "View ID must be a non-empty string."
+    try:
+        vds_path = ds_or_view.save_view(message=message or None, view_id=vid)
+        return str(vds_path), None
+    except Exception as e:
+        return None, f"Failed to save view '{vid}': {e}"
+
+
+def list_saved_views(ds: Any) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Return a simple list-of-dicts snapshot of saved views for display.
+
+    Fields: ``id``, ``message``, ``owner`` (creator uid, from view info),
+    ``commit_id`` (short), ``virtual``. Errors are returned so the UI can
+    surface them without crashing.
+
+    The ``owner`` field is what permission checks compare against: a view
+    can only be deleted by its owner (or dataset creator in admin mode), and
+    UI elements for write-style interactions should be gated accordingly.
+    """
+    try:
+        entries = ds.get_views()
+    except Exception as e:
+        return [], f"Failed to list views: {e}"
+    rows: List[Dict[str, Any]] = []
+    for ve in entries:
+        try:
+            rows.append({
+                "id": ve.id,
+                "message": ve.message or "",
+                "owner": str(ve.get("uid") or "") or "-",
+                "commit_id": (ve.commit_id or "")[:8],
+                "virtual": bool(ve.virtual),
+            })
+        except Exception:
+            continue
+    return rows, None
+
+
+def get_view_entry(ds: Any, view_id: str) -> Tuple[Optional[Any], Optional[str]]:
+    """Return the raw ``ViewEntry`` for ``view_id`` (for origin-card display)."""
+    vid = (view_id or "").strip()
+    if not vid:
+        return None, "View ID must be a non-empty string."
+    try:
+        return ds.get_view(vid), None
+    except KeyError:
+        return None, f"No view with id '{vid}' was found in this dataset."
+    except Exception as e:
+        return None, f"Failed to get view '{vid}': {e}"
+
+
+def load_saved_view(ds: Any, view_id: str) -> Tuple[Optional[Any], Optional[Any], Optional[str]]:
+    """Load a view by id. Returns ``(view_ds, view_entry, error)``.
+
+    ``view_ds`` is a **read-only** sub-dataset (that is MULLER's default for
+    ``load_view``). ``view_entry`` is the raw ViewEntry so the UI can render
+    the view's origin metadata (owner, source commit, original query).
+    """
+    entry, err = get_view_entry(ds, view_id)
+    if err:
+        return None, None, err
+    try:
+        return entry.load(), entry, None
+    except Exception as e:
+        return None, None, f"Failed to load view '{view_id}': {e}"
+
+
+def delete_saved_view(ds: Any, view_id: str) -> Optional[str]:
+    """Delete a view by id. Returns ``None`` on success or an error string."""
+    vid = (view_id or "").strip()
+    if not vid:
+        return "View ID must be a non-empty string."
+    try:
+        ds.delete_view(vid)
+        return None
+    except KeyError:
+        return f"No view with id '{vid}' was found in this dataset."
+    except Exception as e:
+        return f"Failed to delete view '{vid}': {e}"
 
 
 def get_dataset_info(ds: Any) -> Dict[str, Any]:


### PR DESCRIPTION
# Streamlit UI: unified Query & Search, saved-view workflow, user-aware view permissions

## Summary

Reworks the **Query & Search** page of the Streamlit demo so it better supports the collaborative-annotation story (multiple engineers, each on their own branch, handing off query results via views) without fighting MULLER's existing permission model.

Three logical changes, all scoped to `streamlit_ui/`:

1. **Merge conditional filter and vector search into one page.** The old "Vector Search" tab was just placeholder text; it is replaced by a real KNN search form that shares a result pane with conditional filtering.
2. **Add a saved-view workflow.** Users can snapshot any query result as a named view (`ds.save_view(view_id=...)`) and later reload views by id or pick from a list.
3. **Make the view UI permission-aware** so the demo can act as different engineers and the UI never invites an operation the backend would reject.

## What changed

### Query & Search page

- Two tabs (`Conditional Filtering` / `Vector Search`) are replaced by a single form with a `Query mode` radio — one shared result pane and one "Save as view" step.
- **Vector search is now functional.** The mode auto-enumerates `embedding`/`vector` tensors plus any tensor that already has an index under `<ds.path>/_vector_index/<branch>/`. Users can reuse an existing index or build a new one on the fly; query vectors are entered as text and dimension-checked. FAISS returns sample UUIDs, so a `_sample_id_tensor`-based uuid→position mapping is used before handing the hits to `ds[positions]` (falls back to interpreting ids as positions if the backend ever returns them directly). A nearest-neighbour hit list (rank / sample_idx / distance) is shown alongside the main preview.
- Query results persist in `st.session_state` keyed on `(dataset_path, branch, len(ds))`, so paging / tweaking display options no longer drops the active result.

### Saved views

- New `📁 Saved Views` expander at the top of the page:
  - Lists existing views with `owner`, `id`, `message`, `commit`, `virtual`.
  - Lets the user pick a view from a dropdown **or** type an id.
  - `Load View` loads a view (read-only in MULLER, by design) and sets it as the active result.
  - `Delete View` is permission-gated in the UI (see below).
- New `💾 Save result as view` expander at the bottom of the result pane:
  - Takes a user-chosen `view_id` (required) and optional message.
  - Works uniformly for filter results, vector-search results, and results loaded from another engineer's view.

### Permission model (UI side)

MULLER already enforces ownership end-to-end:

- `SensitiveConfig().uid` is the active user; `save_view` stamps `uid = obtain_current_user()` into every view's info block.
- `delete_view` is wrapped in `@user_permission_check`, so non-owner deletes raise `UnAuthorizationError`.
- `load_view` returns a `read_only=True` sub-dataset — others' views are read-only by construction.

The UI now reflects this rather than duplicating it:

- Sidebar gains a `👤 Current user` input that writes to `SensitiveConfig().uid` and reruns. Because `SensitiveConfig` is a process singleton, switching the value mid-session is sufficient to impersonate a different engineer.
- The saved-view table shows `👤 you (<uid>)` for own views and `<uid> (read-only)` for everyone else's.
- `Delete View` + its confirmation checkbox are disabled for views the current user does not own, with a tooltip explaining why (so the demo never surfaces a raw `UnAuthorizationError` stack trace).

### Loaded-view inspector

Added to the shared result pane, visible whenever the active result came from `Load View`:

- **Origin card:** view id, owner badge (`👤 you` / `🔒 read-only · owned by <uid>`), sample count, source commit short hash, virtual flag, saved message, and the **original query string** (from `view_entry.query` / `tql_query` — or a placeholder caption when the view was saved programmatically without one). This is the handoff context an engineer needs to decide whether to reuse the view.
- **Image grid inspector:** fixed 4-column paginated thumbnail grid for any image tensor in the view, with click-to-open full-resolution dialog. If the dataset matches the COCO2017 MULLER schema, a bounding-box / category-name overlay is available (reuses `pil_overlay_coco_bboxes` and `DEFAULT_COCO_INSTANCES_JSON`).
- **Table preview** is moved into its own expander so the inspector doesn't fight with it for vertical space.

### Save-as-view semantics

To make the collaboration handoff explicit:

- If the active result is **my own** view, the view-id field pre-fills with that id (so "Save" behaves like "save a new snapshot under the same name family").
- If the active result is **someone else's** view, the field stays empty and an inline caption reminds the user that saving here creates a **new** view owned by the current user — matching what `_get_view_info` does internally.

## Files changed

- `streamlit_ui/utils.py`
  - New: `current_user`, `set_current_user`, `get_view_entry`.
  - New vector-search helpers: `list_vector_tensor_names`, `list_vector_indexes`, `parse_query_vector`, `tensor_embedding_dim`, `run_vector_search`, `ensure_vector_index`.
  - New saved-view helpers: `save_query_view`, `list_saved_views` (now includes `owner`), `load_saved_view` (returns `(view_ds, view_entry, error)`), `delete_saved_view`.
- `streamlit_ui/demo_streamlit.py`
  - Sidebar: added the `👤 Current user` switcher above navigation.
  - Query & Search page: rewritten as described above.
  - Other pages (Dataset Management, Version Control, Benchmarks, About) are untouched.

## Non-changes / explicit deferrals

- Views returned by `ds.load_view` remain read-only; no in-UI bulk edit / bulk delete is exposed (discussed and deferred — per-view bulk edits would require routing writes through the parent writable dataset using the view's positional indexes, and was not in scope).
- The permission model is not reimplemented in the UI — the UI only gates buttons that would fail at the backend anyway.

## Test plan

- [ ] Run `streamlit run streamlit_ui/demo_streamlit.py` and load an existing MULLER dataset.
- [ ] Conditional filtering still returns the same results as before (spot-check a couple of AND/OR conditions, incl. `CONTAINS` to confirm inverted-index auto-build still fires).
- [ ] On a dataset with an `embedding`/`vector` tensor, run a vector search against an existing index; confirm the hit list shows `rank`, `sample_idx`, `distance`, and the main preview shows the same samples.
- [ ] On a dataset without an existing vector index, type a new index name, run the search, and confirm the index is built then reused on subsequent runs.
- [ ] Run a filter, click **Save as view** with a user-chosen id, confirm it appears in the Saved Views list with `owner = <current user>`.
- [ ] Change the sidebar `Current user` to a second uid, reload the page; confirm the previously-saved view now shows as `<other uid> (read-only)`, the **Delete View** button is disabled, and **Load View** still works (and the origin card shows the `🔒 read-only` badge).
- [ ] Load a view belonging to another user, save it back under a new id; confirm the new view lists the *second* user as owner.
- [ ] On a COCO-schema dataset, load a view, expand **Inspect images**, toggle the bounding-box overlay, click **Full size**.