### PR TITLE
Fix cpp dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,6 +339,11 @@ temp/
 # Project-specific
 # ======================
 
+# C++ build dependencies and generated files
+thirdparty/vendor/
+thirdparty/MurmurHash3.cpp
+tests/data/compulsory_words/*.unix
+
 # Python virtual environments
 venv/
 .env/

--- a/muller/core/query/inverted_index_vectorized.py
+++ b/muller/core/query/inverted_index_vectorized.py
@@ -299,7 +299,8 @@ class InvertedIndexVectorized(object):
             except Exception as e:
                 raise ExecuteError from e
         else:
-            pool = multiprocessing.Pool(num_process)
+            mp_context = multiprocessing.get_context("fork") if hasattr(os, "fork") else multiprocessing
+            pool = mp_context.Pool(num_process)
             # Collect AsyncResults so worker exceptions propagate to the
             # main process via ``.get()`` below, instead of being silently
             # swallowed by ``close() + join()``.
@@ -713,7 +714,8 @@ class InvertedIndexVectorized(object):
             self._obtain_existing_batches()
         )
 
-        pool = multiprocessing.Pool(
+        mp_context = multiprocessing.get_context("fork") if hasattr(os, "fork") else multiprocessing
+        pool = mp_context.Pool(
             processes=min(len(ranges[0]), max_workers),
             maxtasksperchild=1
         )
@@ -838,7 +840,8 @@ class InvertedIndexVectorized(object):
         )
 
         # Initialize process pool
-        pool = multiprocessing.Pool(
+        mp_context = multiprocessing.get_context("fork") if hasattr(os, "fork") else multiprocessing
+        pool = mp_context.Pool(
             processes=min(len(ranges[0]), max_workers),
             maxtasksperchild=1
         )

--- a/muller/util/sparsehash/CMakeLists.txt
+++ b/muller/util/sparsehash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(CustomHashMapPybind)
 
 # Set the C++ standard
@@ -14,17 +14,18 @@ set(VENDOR_DIR "${THIRDPARTY_DIR}/vendor")
 # Set the dependency paths
 set(PYBIND11_INCLUDE_DIR "${VENDOR_DIR}/pybind11/include")
 set(CPPJIEBA_ROOT_DIR "${VENDOR_DIR}/cppjieba")
-set(SPARSEHASH_INCLUDE_DIR "${VENDOR_DIR}/sparsehash/install/include")
-set(BOOST_INCLUDE_DIR "${VENDOR_DIR}/boost/install/include")
-set(BOOST_LIBRARY_DIR "${VENDOR_DIR}/boost/install/lib")
+set(SPARSEHASH_INCLUDE_DIR "${VENDOR_DIR}/sparsehash/sparsehash-install/include")
+set(BOOST_INCLUDE_DIR "${VENDOR_DIR}/boost/boost-install/include")
+set(BOOST_LIBRARY_DIR "${VENDOR_DIR}/boost/boost-install/lib")
 set(MURMURHASH_INCLUDE_DIR "${VENDOR_DIR}/murmurhash/murmurhash/include")
 set(JIEBA_DICT_DIR "${CPPJIEBA_ROOT_DIR}/dict/")
 
 # Set the jiaba dictionary path
 add_definitions(-DJIEBA_DICT_DIR="${JIEBA_DICT_DIR}")
 
-# Search for Python
-find_package(Python3 3.11 EXACT REQUIRED COMPONENTS Development)
+# Search for the Python interpreter selected by the build script, so editable
+# installs inside a conda environment build against the same Python.
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 
 # The source files
 set(SOURCES
@@ -77,10 +78,12 @@ target_compile_definitions(custom_hash_map PRIVATE
 # Link Libraries
 target_link_libraries(custom_hash_map PRIVATE
     ${BOOST_LIBRARY_DIR}/libboost_system.a
-    ${Python3_LIBRARIES}
-    uuid
-    stdc++fs
+    Python3::Module
 )
+
+if(NOT APPLE)
+    target_link_libraries(custom_hash_map PRIVATE uuid stdc++fs)
+endif()
 
 # Release
 target_compile_options(custom_hash_map PRIVATE -O3 -DNDEBUG)

--- a/muller/util/sparsehash/build_proj.sh
+++ b/muller/util/sparsehash/build_proj.sh
@@ -3,13 +3,15 @@
 
 set -e
 
-# Obtain the directory of the scripts
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+# Obtain the directory of the script. Avoid ``readlink -f`` because it is not
+# available on a default macOS installation.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SPARSEHASH_DIR="${SCRIPT_DIR}"  # MULLER/muller/util/sparsehash
 PROJECT_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd) # MULLER
 BUILD_DIR="${SPARSEHASH_DIR}/build"
 THIRDPARTY_DIR="${PROJECT_ROOT}/thirdparty"
 OUTPUT_DIR="${BUILD_DIR}"  # MULLER/muller/util/sparsehash/build
+PYTHON_BIN="${PYTHON:-$(command -v python || command -v python3)}"
 
 # Default args
 CPU_NUM=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
@@ -116,7 +118,7 @@ cd "${BUILD_DIR}"
 echo "Configuring CMake..."
 cmake .. \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-    -DPYTHON_EXECUTABLE=$(which python3)
+    -DPython3_EXECUTABLE="${PYTHON_BIN}"
 
 # Building
 echo "Building..."

--- a/muller/util/sparsehash/src/index_utils.cpp
+++ b/muller/util/sparsehash/src/index_utils.cpp
@@ -10,13 +10,19 @@
 #include "custom_hash_map.h"
 #include "gil_manager.h"
 #include "logger.h"
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "No filesystem support found"
+#endif
 #include <thread>
 #include <mutex>
 #include <atomic>
 #include <iostream>
-
-namespace fs = std::experimental::filesystem;
 
 namespace hashmap {
 namespace index_utils {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,10 @@
 #
 # Copyright (c) 2026 Xueling Lin
 
+import os
+
+os.environ.setdefault("MULLER_PYTEST_ENABLED", "true")
+
 import pytest
 
 

--- a/tests/integration/indexing/test_inverted_index_local.py
+++ b/tests/integration/indexing/test_inverted_index_local.py
@@ -20,6 +20,28 @@ from tests.constants import TEST_INDEX_PATH
 from tests.utils import official_path, official_creds
 
 
+TEST_DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "data"))
+
+
+def _test_data_path(*parts):
+    return os.path.join(TEST_DATA_DIR, *parts)
+
+
+def _stop_words_list():
+    return [
+        _test_data_path("stop_words", "baidu_stopwords.txt"),
+        _test_data_path("stop_words", "cn_stopwords.txt"),
+        _test_data_path("stop_words", "hit_stopwords.txt"),
+        _test_data_path("stop_words", "scu_stopwords.txt"),
+        _test_data_path("stop_words", "common_stopwords.txt"),
+        _test_data_path("stop_words", "stopwords-en.txt"),
+    ]
+
+
+def _compulsory_words_path():
+    return _test_data_path("compulsory_words", "compulsory_words.txt")
+
+
 def is_ci_environment():
     """Check if it is running in CI online."""
     return os.getenv('JENKINS_URL') is not None or os.getenv('CI') == 'true'
@@ -36,13 +58,8 @@ def get_test_params():
 def test_cpp_python_mix(storage):
     ds = muller.empty(official_path(storage, TEST_INDEX_PATH), creds=official_creds(storage), overwrite=True)
 
-    stop_words_list = ["data/stop_words/baidu_stopwords.txt",
-                       "data/stop_words/cn_stopwords.txt",
-                       "data/stop_words/hit_stopwords.txt",
-                       "data/stop_words/scu_stopwords.txt",
-                       "data/stop_words/common_stopwords.txt",
-                       "data/stop_words/stopwords-en.txt", ]
-    compulsory_words = "data/compulsory_words/compulsory_words.txt"
+    stop_words_list = _stop_words_list()
+    compulsory_words = _compulsory_words_path()
     values = ["白日依山尽，黄河入海流，欲穷千里目，更上一层楼",
               "床前明月光，疑是地上霜，举头邀明月，低头思故乡",
               "京口瓜洲一水间，钟山只隔数重山。 春风又绿江南岸，明月何时照我还？",
@@ -160,13 +177,8 @@ def test_inverted_index(storage, use_cpp):
 
     ds.create_index_vectorized = patched_create_index_vec
 
-    stop_words_list = ["data/stop_words/baidu_stopwords.txt",
-                       "data/stop_words/cn_stopwords.txt",
-                       "data/stop_words/hit_stopwords.txt",
-                       "data/stop_words/scu_stopwords.txt",
-                       "data/stop_words/common_stopwords.txt",
-                       "data/stop_words/stopwords-en.txt", ]
-    compulsory_words = "data/compulsory_words/compulsory_words.txt"
+    stop_words_list = _stop_words_list()
+    compulsory_words = _compulsory_words_path()
     values = ["白日依山尽，黄河入海流，欲穷千里目，更上一层楼",
               "床前明月光，疑是地上霜，举头邀明月，低头思故乡",
               "京口瓜洲一水间，钟山只隔数重山。 春风又绿江南岸，明月何时照我还？",

--- a/thirdparty/build_deps.sh
+++ b/thirdparty/build_deps.sh
@@ -3,11 +3,13 @@
 
 set -e
 
-CUR_DIR=$(dirname $(readlink -f "$0"))
+CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 THIRDPARTY_DIR="${CUR_DIR}"  # MULLER/thirdparty
 VENDOR_DIR="${THIRDPARTY_DIR}/vendor"
 BUILD_OUT_DIR="${VENDOR_DIR}/lib"
 DEPS_SCRIPT="${CUR_DIR}/download_opensource.sh"
+SPARSEHASH_INSTALL_DIR="${VENDOR_DIR}/sparsehash/sparsehash-install"
+BOOST_INSTALL_DIR="${VENDOR_DIR}/boost/boost-install"
 
 # Default number of parallel compilation jobs.
 CPU_NUM=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
@@ -105,7 +107,7 @@ build_sparsehash() {
 
     # Perform the standard three-step build process.
     echo "Running ./configure..."
-    ./configure --prefix="${VENDOR_DIR}/sparsehash/install"
+    ./configure --prefix="${SPARSEHASH_INSTALL_DIR}"
 
     echo "Running make..."
     make -j${JOB_NUM}
@@ -129,7 +131,7 @@ build_boost() {
     cd "${boost_dir}"
 
     # Bootstrap
-    ./bootstrap.sh --prefix="${boost_dir}/install"
+    ./bootstrap.sh --prefix="${BOOST_INSTALL_DIR}"
 
     # Compile only the required libraries.
     ./b2 -j${JOB_NUM} \

--- a/thirdparty/download_opensource.sh
+++ b/thirdparty/download_opensource.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2026 Bingyu Liu. All rights reserved.
 
-CUR_DIR=$(dirname $(readlink -f "$0"))
+CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set -e
 
 export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
@@ -13,7 +13,8 @@ echo -e "Starting dependency download..."
 while getopts 'T:F:' opt; do
     case "$opt" in
     T)
-        THIRD_PARTY_DIR=$(readlink -f "${OPTARG}")
+        mkdir -p "${OPTARG}"
+        THIRD_PARTY_DIR="$(cd "${OPTARG}" && pwd)"
         ;;
     F)
         DEPS_CSV="${OPTARG}"
@@ -28,6 +29,8 @@ done
 if [ ! -d "${THIRD_PARTY_DIR}" ]; then
   mkdir -p "${THIRD_PARTY_DIR}"
 fi
+GIT_TEMPLATE_DIR="${THIRD_PARTY_DIR}/.git-template-empty"
+mkdir -p "${GIT_TEMPLATE_DIR}"
 
 function git_clone_open_src() {
     local name="$1"
@@ -46,7 +49,7 @@ function git_clone_open_src() {
     mkdir "$name" && cd "$name"
 
     # Try to git clone using tag
-    if git lfs clone --depth 1 -b $tag --recursive $repo . 2>/dev/null; then
+    if git clone --template="${GIT_TEMPLATE_DIR}" --depth 1 -b "$tag" --recursive "$repo" . 2>/dev/null; then
         echo "Successfully cloned ${name} with tag ${tag}"
     else
         # If the tag does not exist, use the default branch
@@ -54,7 +57,7 @@ function git_clone_open_src() {
         cd ..
         rm -rf "$name"
         mkdir "$name" && cd "$name"
-        git lfs clone --depth 1 --recursive $repo .
+        git clone --template="${GIT_TEMPLATE_DIR}" --depth 1 --recursive "$repo" .
     fi
 
     if [ -f ".gitmodules" ]; then


### PR DESCRIPTION
## Summary

- Fix local inverted index tests by resolving stop word and compulsory word paths relative to the test data directory.
- Make sparsehash C++ extension builds portable across macOS and Linux by improving script path resolution, Python selection, CMake Python module linking, filesystem headers, and dependency install paths.
- Use fork-based multiprocessing for local index build/merge workers to avoid read-only storage state after spawning test workers.
- Enable pytest-specific local dataset lock behavior in test setup and ignore generated C++ dependency/temp files.

## Test Plan

- [x] `conda run -n muller pytest tests/integration/indexing/test_inverted_index_local.py -q`
- [x] Verified `muller.util.sparsehash.build.custom_hash_map` imports successfully in the `muller` conda environment.