### PR TITLE
Adopt column-first public API terminology

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -9,7 +9,7 @@ This directory contains Agent Skills for managing MULLER datasets through natura
 
 **Capabilities:**
 - Create and load datasets
-- Manage tensors (create, delete, rename)
+- Manage columns (create, delete, rename)
 - Add, update, delete data
 - Query and filter samples
 - Import data from files
@@ -59,13 +59,13 @@ This directory contains Agent Skills for managing MULLER datasets through natura
 - Export to Apache Arrow format
 - Export to Parquet files
 - Export to JSON format
-- Convert tensors to NumPy arrays
+- Convert columns to NumPy arrays
 - Export to MindRecord format (MindSpore)
 - Integrate with PyTorch, TensorFlow, and other frameworks
 
 **Example Commands:**
 - "Export dataset to Parquet format"
-- "Convert embeddings tensor to NumPy"
+- "Convert embeddings column to NumPy"
 - "Export to JSON for web API"
 - "Export to Arrow for data sharing"
 
@@ -131,7 +131,7 @@ Each skill is designed to stay within reasonable token limits:
 User: "Create an image dataset, add photos, commit changes, and export to Parquet"
 
 Agent uses:
-1. muller-dataset: Create dataset with image tensors
+1. muller-dataset: Create dataset with image columns
 2. muller-dataset: Import images from directory
 3. muller-version-control: Commit changes
 4. muller-export: Export to Parquet format

--- a/.claude/skills/muller-advanced-query/SKILL.md
+++ b/.claude/skills/muller-advanced-query/SKILL.md
@@ -49,22 +49,22 @@ Handles advanced query and indexing operations.
 ```bash
 # Create inverted index for text search
 python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py create-index \
-  --path ./my_dataset --tensors "description,title"
+  --path ./my_dataset --columns "description,title"
 
 # Create vector index
 python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py create-vector-index \
-  --path ./my_dataset --tensor embeddings --index-name hnsw \
+  --path ./my_dataset --column embeddings --index-name hnsw \
   --index-type HNSWFLAT --metric l2
 
 # Vector search
 python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py vector-search \
-  --path ./my_dataset --tensor embeddings --index-name hnsw \
+  --path ./my_dataset --column embeddings --index-name hnsw \
   --query-file query.npy --topk 10
 
 # Aggregation
 python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py aggregate \
   --path ./my_dataset --group-by categories --select labels,categories \
-  --aggregate-tensors "*"
+  --aggregate-columns "*"
 ```
 
 ## Quick Reference

--- a/.claude/skills/muller-advanced-query/scripts/advanced_query.py
+++ b/.claude/skills/muller-advanced-query/scripts/advanced_query.py
@@ -15,7 +15,7 @@ import os
 import numpy as np
 
 # Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
 
 try:
     import muller
@@ -34,17 +34,19 @@ def create_index(args):
     try:
         ds = muller.load(args.path)
 
-        tensors = args.tensors.split(",") if args.tensors else None
-        ds.create_index(tensors)
+        columns_arg = args.columns or args.tensors
+        columns = columns_arg.split(",") if columns_arg else None
+        ds.create_index(columns)
 
         return {
             "success": True,
             "operation": "create_index",
             "result": {
                 "path": args.path,
-                "tensors": tensors
+                "columns": columns,
+                "tensors": columns
             },
-            "message": f"Created inverted index for {len(tensors) if tensors else 'all'} tensors"
+            "message": f"Created inverted index for {len(columns) if columns else 'all'} columns"
         }
     except Exception as e:
         return {
@@ -60,6 +62,9 @@ def create_vector_index(args):
     """Create vector index."""
     try:
         ds = muller.load(args.path)
+        column = args.column or args.tensor
+        if not column:
+            raise ValueError("Column name is required")
 
         kwargs = {
             "index_name": args.index_name,
@@ -75,14 +80,15 @@ def create_vector_index(args):
         if args.nlist:
             kwargs["nlist"] = args.nlist
 
-        ds.create_vector_index(args.tensor, **kwargs)
+        ds.create_vector_index(column, **kwargs)
 
         return {
             "success": True,
             "operation": "create_vector_index",
             "result": {
                 "path": args.path,
-                "tensor": args.tensor,
+                "column": column,
+                "tensor": column,
                 "index_name": args.index_name,
                 "index_type": args.index_type
             },
@@ -102,14 +108,18 @@ def load_vector_index(args):
     """Load vector index into memory."""
     try:
         ds = muller.load(args.path)
-        ds.load_vector_index(args.tensor, index_name=args.index_name)
+        column = args.column or args.tensor
+        if not column:
+            raise ValueError("Column name is required")
+        ds.load_vector_index(column, index_name=args.index_name)
 
         return {
             "success": True,
             "operation": "load_vector_index",
             "result": {
                 "path": args.path,
-                "tensor": args.tensor,
+                "column": column,
+                "tensor": column,
                 "index_name": args.index_name
             },
             "message": f"Loaded vector index: {args.index_name}"
@@ -127,6 +137,9 @@ def vector_search(args):
     """Perform vector similarity search."""
     try:
         ds = muller.load(args.path, read_only=True)
+        column = args.column or args.tensor
+        if not column:
+            raise ValueError("Column name is required")
 
         # Load query vectors
         if args.query_file:
@@ -146,7 +159,7 @@ def vector_search(args):
 
         distances, indices = ds.vector_search(
             query_vector=query_vector,
-            tensor_name=args.tensor,
+            column_name=column,
             index_name=args.index_name,
             **kwargs
         )
@@ -156,7 +169,8 @@ def vector_search(args):
             "operation": "vector_search",
             "result": {
                 "path": args.path,
-                "tensor": args.tensor,
+                "column": column,
+                "tensor": column,
                 "index_name": args.index_name,
                 "num_queries": len(query_vector),
                 "topk": args.topk,
@@ -184,19 +198,20 @@ def aggregate_query(args):
         selected = args.select.split(",") if args.select else []
         order_by = args.order_by.split(",") if args.order_by else []
 
-        # Parse aggregate tensors
-        aggregate_tensors = []
-        if args.aggregate_tensors:
-            if args.aggregate_tensors == "*":
-                aggregate_tensors = ["*"]
+        # Parse aggregate columns. The legacy --aggregate-tensors flag is still accepted.
+        aggregate_columns_arg = args.aggregate_columns or args.aggregate_tensors
+        aggregate_columns = []
+        if aggregate_columns_arg:
+            if aggregate_columns_arg == "*":
+                aggregate_columns = ["*"]
             else:
-                aggregate_tensors = args.aggregate_tensors.split(",")
+                aggregate_columns = aggregate_columns_arg.split(",")
 
         result = ds.aggregate_vectorized(
-            group_by_tensors=group_by,
-            selected_tensors=selected,
-            order_by_tensors=order_by,
-            aggregate_tensors=aggregate_tensors
+            group_by_columns=group_by,
+            selected_columns=selected,
+            order_by_columns=order_by,
+            aggregate_columns=aggregate_columns
         )
 
         return {
@@ -230,7 +245,7 @@ def filter_advanced(args):
             for cond in args.conditions.split(";"):
                 parts = cond.split(",")
                 if len(parts) >= 3:
-                    tensor, op, value = parts[0], parts[1], ",".join(parts[2:])
+                    column, op, value = parts[0], parts[1], ",".join(parts[2:])
                     # Try to convert value to number
                     try:
                         if "." in value:
@@ -239,7 +254,7 @@ def filter_advanced(args):
                             value = int(value)
                     except ValueError:
                         value = value.strip('"\'')
-                    conditions.append((tensor, op, value))
+                    conditions.append((column, op, value))
 
         # Parse connectors
         connectors = args.connectors.split(",") if args.connectors else []
@@ -286,12 +301,14 @@ def main():
     # Create index command
     create_index_parser = subparsers.add_parser("create-index", help="Create inverted index")
     create_index_parser.add_argument("--path", required=True, help="Dataset path")
-    create_index_parser.add_argument("--tensors", help="Comma-separated tensor names")
+    create_index_parser.add_argument("--columns", help="Comma-separated column names")
+    create_index_parser.add_argument("--tensors", help=argparse.SUPPRESS)
 
     # Create vector index command
     create_vector_index_parser = subparsers.add_parser("create-vector-index", help="Create vector index")
     create_vector_index_parser.add_argument("--path", required=True, help="Dataset path")
-    create_vector_index_parser.add_argument("--tensor", required=True, help="Tensor name")
+    create_vector_index_parser.add_argument("--column", help="Column name")
+    create_vector_index_parser.add_argument("--tensor", help=argparse.SUPPRESS)
     create_vector_index_parser.add_argument("--index-name", required=True, help="Index name")
     create_vector_index_parser.add_argument("--index-type", required=True, help="Index type: FLAT/HNSWFLAT/DISKANN")
     create_vector_index_parser.add_argument("--metric", default="l2", help="Distance metric: l2/cosine")
@@ -302,13 +319,15 @@ def main():
     # Load vector index command
     load_vector_index_parser = subparsers.add_parser("load-vector-index", help="Load vector index")
     load_vector_index_parser.add_argument("--path", required=True, help="Dataset path")
-    load_vector_index_parser.add_argument("--tensor", required=True, help="Tensor name")
+    load_vector_index_parser.add_argument("--column", help="Column name")
+    load_vector_index_parser.add_argument("--tensor", help=argparse.SUPPRESS)
     load_vector_index_parser.add_argument("--index-name", required=True, help="Index name")
 
     # Vector search command
     vector_search_parser = subparsers.add_parser("vector-search", help="Vector similarity search")
     vector_search_parser.add_argument("--path", required=True, help="Dataset path")
-    vector_search_parser.add_argument("--tensor", required=True, help="Tensor name")
+    vector_search_parser.add_argument("--column", help="Column name")
+    vector_search_parser.add_argument("--tensor", help=argparse.SUPPRESS)
     vector_search_parser.add_argument("--index-name", required=True, help="Index name")
     vector_search_parser.add_argument("--query-file", required=True, help="Query vectors file (.npy)")
     vector_search_parser.add_argument("--topk", type=int, default=10, help="Top K results")
@@ -317,15 +336,16 @@ def main():
     # Aggregate command
     aggregate_parser = subparsers.add_parser("aggregate", help="Aggregation query")
     aggregate_parser.add_argument("--path", required=True, help="Dataset path")
-    aggregate_parser.add_argument("--group-by", help="Comma-separated group by tensors")
-    aggregate_parser.add_argument("--select", help="Comma-separated selected tensors")
-    aggregate_parser.add_argument("--order-by", help="Comma-separated order by tensors")
-    aggregate_parser.add_argument("--aggregate-tensors", help="Aggregate tensors (* or tensor:func)")
+    aggregate_parser.add_argument("--group-by", help="Comma-separated group by columns")
+    aggregate_parser.add_argument("--select", help="Comma-separated selected columns")
+    aggregate_parser.add_argument("--order-by", help="Comma-separated order by columns")
+    aggregate_parser.add_argument("--aggregate-columns", help="Aggregate columns (* or column:func)")
+    aggregate_parser.add_argument("--aggregate-tensors", help=argparse.SUPPRESS)
 
     # Filter advanced command
     filter_parser = subparsers.add_parser("filter-advanced", help="Advanced filtering")
     filter_parser.add_argument("--path", required=True, help="Dataset path")
-    filter_parser.add_argument("--conditions", help="Conditions: tensor,op,value;...")
+    filter_parser.add_argument("--conditions", help="Conditions: column,op,value;...")
     filter_parser.add_argument("--connectors", help="Connectors: AND,OR,NOT")
     filter_parser.add_argument("--offset", type=int, default=0, help="Offset")
     filter_parser.add_argument("--limit", type=int, help="Limit")

--- a/.claude/skills/muller-dataset/SKILL.md
+++ b/.claude/skills/muller-dataset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: muller-dataset
-description: Create, query, and manage MULLER datasets (multimodal data lake with version control). Use when user wants to work with datasets, create tensors, append data, query samples, or inspect dataset information.
+description: Create, query, and manage MULLER datasets (multimodal data lake with version control). Use when user wants to work with datasets, create columns, append data, query samples, or inspect dataset information.
 compatibility: Requires Python 3.11+, muller package installed
 ---
 
@@ -9,7 +9,7 @@ compatibility: Requires Python 3.11+, muller package installed
 ## IMPORTANT: How to Use This Skill
 
 **DO NOT create new Python files.** Always use the existing scripts provided in this skill:
-- Use `scripts/dataset_manager.py` for dataset and tensor management
+- Use `scripts/dataset_manager.py` for dataset and column management
 - Use `scripts/data_operations.py` for data CRUD operations
 
 Execute these scripts directly with `python3` command. Never write new scripts to the project root.
@@ -28,7 +28,7 @@ Use this skill when the user wants to:
 - Create or load MULLER datasets
 - Add data to datasets (images, text, labels, vectors, etc.)
 - Query or filter dataset samples
-- Manage dataset structure (create/delete/rename tensors)
+- Manage dataset structure (create/delete/rename columns)
 - Inspect dataset information (summary, statistics)
 - Import data from files or directories
 
@@ -44,24 +44,25 @@ Manages dataset lifecycle and structure.
 - `delete` - Delete a dataset
 - `info` - Get dataset information
 - `stats` - Get dataset statistics
-- `create-tensor` - Create a new tensor
-- `delete-tensor` - Delete a tensor
-- `rename-tensor` - Rename a tensor
+- `create-column` - Create a new column
+- `delete-column` - Delete a column
+- `rename-column` - Rename a column
+  - Legacy `create-tensor`, `delete-tensor`, and `rename-tensor` commands remain accepted.
 
 **Usage:**
 ```bash
 # Create dataset
 python3 .claude/skills/muller-dataset/scripts/dataset_manager.py create --path ./my_dataset
 
-# Create with tensors
+# Create with columns
 python3 .claude/skills/muller-dataset/scripts/dataset_manager.py create --path ./my_dataset \
-  --tensors "images:image:jpg,labels:class_label:uint32"
+  --columns "images:image:jpg,labels:class_label:uint32"
 
 # Get info
 python3 .claude/skills/muller-dataset/scripts/dataset_manager.py info --path ./my_dataset
 
-# Create tensor
-python3 .claude/skills/muller-dataset/scripts/dataset_manager.py create-tensor --path ./my_dataset \
+# Create column
+python3 .claude/skills/muller-dataset/scripts/dataset_manager.py create-column --path ./my_dataset \
   --name embeddings --htype vector --dtype float32
 ```
 

--- a/.claude/skills/muller-dataset/references/api-cheatsheet.md
+++ b/.claude/skills/muller-dataset/references/api-cheatsheet.md
@@ -16,23 +16,23 @@ ds = muller.empty(path, overwrite=False)
 muller.delete(path, large_ok=False)
 
 # Copy structure
-muller.like(dest, src, tensors=None, overwrite=False)
+muller.like(dest, src, columns=None, overwrite=False)
 ```
 
-## Tensor Management
+## Column Management
 
 ```python
-# Create tensor
-ds.create_tensor(name, htype="generic", dtype=None, sample_compression=None)
+# Create column
+ds.create_column(name, htype="generic", dtype=None, sample_compression=None)
 
-# Delete tensor
-ds.delete_tensor(name, large_ok=False)
+# Delete column
+ds.delete_column(name, large_ok=False)
 
-# Rename tensor
-ds.rename_tensor(old_name, new_name)
+# Rename column
+ds.rename_column(old_name, new_name)
 
-# Copy tensor structure
-ds.create_tensor_like(name, source_tensor)
+# Copy column structure
+ds.create_column_like(name, source_column)
 ```
 
 ## Data Operations
@@ -40,15 +40,15 @@ ds.create_tensor_like(name, source_tensor)
 ```python
 # Append single sample
 with ds:
-    ds.append({"tensor1": value1, "tensor2": value2})
+    ds.append({"column1": value1, "column2": value2})
 
 # Extend with multiple samples
 with ds:
-    ds.extend({"tensor1": [v1, v2], "tensor2": [v3, v4]})
+    ds.extend({"column1": [v1, v2], "column2": [v3, v4]})
 
 # Update sample
 with ds:
-    ds[index].update({"tensor1": new_value})
+    ds[index].update({"column1": new_value})
 
 # Delete samples
 with ds:
@@ -60,7 +60,7 @@ with ds:
 
 ```python
 # Filter samples
-result = ds.filter_vectorized([("tensor", "op", value)])
+result = ds.filter_vectorized([("column", "op", value)])
 
 # Operators: ==, !=, >, <, >=, <=, CONTAINS
 result = ds.filter_vectorized([("labels", ">", 5)])
@@ -88,8 +88,8 @@ stats = ds.statistics()
 # Sample count
 count = ds.num_samples
 
-# Tensor list
-tensors = ds.tensors
+# Column list
+columns = ds.columns
 
 # Dataset info
 info = ds.info
@@ -106,7 +106,7 @@ ds = muller.from_dataframes(dataframes, muller_path, schema=None)
 
 # Schema format
 schema = {
-    "tensor_name": (htype, dtype, compression),
+    "column_name": (htype, dtype, compression),
     "images": ("image", "uint8", "jpg"),
     "labels": ("class_label", "uint32", None)
 }
@@ -125,7 +125,7 @@ schema = {
 ## Return Types
 
 - `Dataset` - Dataset object
-- `Tensor` - Tensor object
+- `Tensor` - Column object (internal storage class name)
 - `dict` - Statistics, info
 - `int` - Sample count, size
 - `None` - Operations with side effects

--- a/.claude/skills/muller-dataset/references/htypes-guide.md
+++ b/.claude/skills/muller-dataset/references/htypes-guide.md
@@ -12,7 +12,7 @@ MULLER supports 12+ high-level data types (htypes) for different kinds of data.
 **Compression:** jpg, png, webp, bmp, gif, tiff, etc.
 
 ```python
-ds.create_tensor("photos", htype="image", sample_compression="jpg")
+ds.create_column("photos", htype="image", sample_compression="jpg")
 ds.photos.append(muller.read("photo.jpg"))
 ```
 
@@ -22,7 +22,7 @@ ds.photos.append(muller.read("photo.jpg"))
 **Compression:** mp4, mkv, avi
 
 ```python
-ds.create_tensor("videos", htype="video", sample_compression="mp4")
+ds.create_column("videos", htype="video", sample_compression="mp4")
 ds.videos.append(muller.read("video.mp4"))
 ```
 
@@ -32,7 +32,7 @@ ds.videos.append(muller.read("video.mp4"))
 **Compression:** mp3, wav, flac
 
 ```python
-ds.create_tensor("audio", htype="audio", sample_compression="mp3")
+ds.create_column("audio", htype="audio", sample_compression="mp3")
 ds.audio.append(muller.read("audio.mp3"))
 ```
 
@@ -42,7 +42,7 @@ ds.audio.append(muller.read("audio.mp3"))
 **Compression:** None, lz4 (optional)
 
 ```python
-ds.create_tensor("descriptions", htype="text")
+ds.create_column("descriptions", htype="text")
 ds.descriptions.append("A beautiful sunset")
 ```
 
@@ -52,7 +52,7 @@ ds.descriptions.append("A beautiful sunset")
 **Compression:** None, lz4 (optional)
 
 ```python
-ds.create_tensor("embeddings", htype="vector", dtype="float32")
+ds.create_column("embeddings", htype="vector", dtype="float32")
 ds.embeddings.append(np.array([0.1, 0.2, 0.3]))
 ```
 
@@ -62,7 +62,7 @@ ds.embeddings.append(np.array([0.1, 0.2, 0.3]))
 **Compression:** None, lz4 (optional)
 
 ```python
-ds.create_tensor("labels", htype="class_label", dtype="uint32")
+ds.create_column("labels", htype="class_label", dtype="uint32")
 ds.labels.append(5)
 ```
 
@@ -72,7 +72,7 @@ ds.labels.append(5)
 **Compression:** None, lz4 (optional)
 
 ```python
-ds.create_tensor("boxes", htype="bbox", dtype="float32")
+ds.create_column("boxes", htype="bbox", dtype="float32")
 ds.boxes.append([x, y, width, height])
 ```
 
@@ -81,7 +81,7 @@ ds.boxes.append([x, y, width, height])
 **Compression:** None, lz4 (optional)
 
 ```python
-ds.create_tensor("metadata", htype="json")
+ds.create_column("metadata", htype="json")
 ds.metadata.append({"key": "value", "count": 42})
 ```
 
@@ -90,7 +90,7 @@ ds.metadata.append({"key": "value", "count": 42})
 **Compression:** None, lz4 (optional)
 
 ```python
-ds.create_tensor("tags", htype="list")
+ds.create_column("tags", htype="list")
 ds.tags.append(["tag1", "tag2", "tag3"])
 ```
 
@@ -100,7 +100,7 @@ ds.tags.append(["tag1", "tag2", "tag3"])
 **Compression:** None, lz4 (optional)
 
 ```python
-ds.create_tensor("scores", htype="generic", dtype="float32")
+ds.create_column("scores", htype="generic", dtype="float32")
 ds.scores.append(0.95)
 ```
 
@@ -141,21 +141,21 @@ ds.scores.append(0.95)
 
 ### Image Classification Dataset
 ```python
-ds.create_tensor("images", htype="image", sample_compression="jpg")
-ds.create_tensor("labels", htype="class_label", dtype="uint32")
+ds.create_column("images", htype="image", sample_compression="jpg")
+ds.create_column("labels", htype="class_label", dtype="uint32")
 ```
 
 ### Text Dataset with Embeddings
 ```python
-ds.create_tensor("text", htype="text")
-ds.create_tensor("embeddings", htype="vector", dtype="float32")
+ds.create_column("text", htype="text")
+ds.create_column("embeddings", htype="vector", dtype="float32")
 ```
 
 ### Object Detection Dataset
 ```python
-ds.create_tensor("images", htype="image", sample_compression="jpg")
-ds.create_tensor("boxes", htype="bbox", dtype="float32")
-ds.create_tensor("labels", htype="class_label", dtype="uint32")
+ds.create_column("images", htype="image", sample_compression="jpg")
+ds.create_column("boxes", htype="bbox", dtype="float32")
+ds.create_column("labels", htype="class_label", dtype="uint32")
 ```
 
 For complete details, see [../../docs/api/htypes.md](../../docs/api/htypes.md)

--- a/.claude/skills/muller-dataset/references/quick-start.md
+++ b/.claude/skills/muller-dataset/references/quick-start.md
@@ -10,15 +10,15 @@ import muller
 # Create empty dataset
 ds = muller.dataset("./my_dataset", overwrite=True)
 
-# Create tensors
-ds.create_tensor("images", htype="image", sample_compression="jpg")
-ds.create_tensor("labels", htype="class_label", dtype="uint32")
+# Create columns
+ds.create_column("images", htype="image", sample_compression="jpg")
+ds.create_column("labels", htype="class_label", dtype="uint32")
 ```
 
 **Via skill:**
 ```bash
 uv run scripts/dataset_manager.py create --path ./my_dataset \
-  --tensors "images:image:jpg,labels:class_label:uint32"
+  --columns "images:image:jpg,labels:class_label:uint32"
 ```
 
 ### 2. Add Data
@@ -104,18 +104,18 @@ with ds:
     ds.pop([0, 5, 10])
 ```
 
-### Tensor Management
+### Column Management
 
 ```python
 with ds:
-    # Create tensor
-    ds.create_tensor("embeddings", htype="vector", dtype="float32")
+    # Create column
+    ds.create_column("embeddings", htype="vector", dtype="float32")
 
-    # Rename tensor
-    ds.rename_tensor("old_name", "new_name")
+    # Rename column
+    ds.rename_column("old_name", "new_name")
 
-    # Delete tensor
-    ds.delete_tensor("temp_tensor")
+    # Delete column
+    ds.delete_column("temp_column")
 ```
 
 ## Storage Backends

--- a/.claude/skills/muller-dataset/scripts/data_operations.py
+++ b/.claude/skills/muller-dataset/scripts/data_operations.py
@@ -15,7 +15,7 @@ import os
 from pathlib import Path
 
 # Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
 
 try:
     import muller
@@ -140,10 +140,10 @@ def query_samples(args):
         ds = muller.load(args.path, read_only=True)
 
         if args.filter:
-            # Parse filter: "tensor op value"
+            # Parse filter: "column op value"
             parts = args.filter.split()
             if len(parts) >= 3:
-                tensor = parts[0]
+                column = parts[0]
                 op = parts[1]
                 value = " ".join(parts[2:])
 
@@ -156,7 +156,7 @@ def query_samples(args):
                 except ValueError:
                     value = value.strip('"\'')
 
-                result = ds.filter_vectorized([(tensor, op, value)])
+                result = ds.filter_vectorized([(column, op, value)])
             else:
                 result = ds
         else:
@@ -250,7 +250,7 @@ def main():
     # Query command
     query_parser = subparsers.add_parser("query", help="Query samples")
     query_parser.add_argument("--path", required=True, help="Dataset path")
-    query_parser.add_argument("--filter", help="Filter: 'tensor op value'")
+    query_parser.add_argument("--filter", help="Filter: 'column op value'")
     query_parser.add_argument("--limit", type=int, help="Max results")
 
     # Import command

--- a/.claude/skills/muller-dataset/scripts/dataset_manager.py
+++ b/.claude/skills/muller-dataset/scripts/dataset_manager.py
@@ -5,7 +5,7 @@
 """
 MULLER Dataset Manager - Manage dataset lifecycle and structure.
 
-Operations: create, load, delete, info, stats, create-tensor, delete-tensor, rename-tensor
+Operations: create, load, delete, info, stats, create-column, delete-column, rename-column
 """
 
 import argparse
@@ -14,7 +14,7 @@ import sys
 import os
 
 # Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
 
 try:
     import muller
@@ -33,12 +33,13 @@ def create_dataset(args):
     try:
         ds = muller.dataset(args.path, overwrite=args.overwrite)
 
-        # Create tensors if specified
-        tensors_created = []
-        if args.tensors:
+        # Create columns if specified. The legacy --tensors flag is still accepted.
+        columns_created = []
+        column_specs = args.columns or args.tensors
+        if column_specs:
             with ds:
-                for tensor_spec in args.tensors.split(","):
-                    parts = tensor_spec.split(":")
+                for column_spec in column_specs.split(","):
+                    parts = column_spec.split(":")
                     name = parts[0]
                     htype = parts[1] if len(parts) > 1 else "generic"
                     param3 = parts[2] if len(parts) > 2 else None
@@ -54,16 +55,18 @@ def create_dataset(args):
                         else:
                             dtype = param3
 
-                    ds.create_tensor(name, htype=htype, sample_compression=compression, dtype=dtype)
-                    tensors_created.append(name)
+                    ds.create_column(name, htype=htype, sample_compression=compression, dtype=dtype)
+                    columns_created.append(name)
 
         return {
             "success": True,
             "operation": "create_dataset",
             "result": {
                 "path": args.path,
-                "num_tensors": len(tensors_created),
-                "tensors": tensors_created
+                "num_columns": len(columns_created),
+                "columns": columns_created,
+                "num_tensors": len(columns_created),
+                "tensors": columns_created
             },
             "message": f"Dataset created at {args.path}"
         }
@@ -88,6 +91,8 @@ def get_info(args):
             "result": {
                 "path": args.path,
                 "num_samples": ds.num_samples,
+                "columns": list(ds.columns.keys()),
+                "num_columns": len(ds.columns),
                 "tensors": list(ds.tensors.keys()),
                 "num_tensors": len(ds.tensors)
             },
@@ -144,13 +149,13 @@ def delete_dataset(args):
         }
 
 
-def create_tensor(args):
-    """Create a new tensor."""
+def create_column(args):
+    """Create a new column."""
     try:
         ds = muller.load(args.path)
 
         with ds:
-            ds.create_tensor(
+            ds.create_column(
                 args.name,
                 htype=args.htype,
                 dtype=args.dtype,
@@ -159,69 +164,70 @@ def create_tensor(args):
 
         return {
             "success": True,
-            "operation": "create_tensor",
+            "operation": "create_column",
             "result": {
                 "path": args.path,
+                "column": args.name,
                 "tensor": args.name,
                 "htype": args.htype
             },
-            "message": f"Tensor '{args.name}' created"
+            "message": f"Column '{args.name}' created"
         }
     except Exception as e:
         return {
             "success": False,
-            "operation": "create_tensor",
+            "operation": "create_column",
             "error": type(e).__name__,
             "message": str(e),
-            "suggestion": "Check if tensor already exists"
+            "suggestion": "Check if column already exists"
         }
 
 
-def delete_tensor(args):
-    """Delete a tensor."""
+def delete_column(args):
+    """Delete a column."""
     try:
         ds = muller.load(args.path)
 
         with ds:
-            ds.delete_tensor(args.name, large_ok=args.large_ok)
+            ds.delete_column(args.name, large_ok=args.large_ok)
 
         return {
             "success": True,
-            "operation": "delete_tensor",
-            "result": {"path": args.path, "tensor": args.name},
-            "message": f"Tensor '{args.name}' deleted"
+            "operation": "delete_column",
+            "result": {"path": args.path, "column": args.name, "tensor": args.name},
+            "message": f"Column '{args.name}' deleted"
         }
     except Exception as e:
         return {
             "success": False,
-            "operation": "delete_tensor",
+            "operation": "delete_column",
             "error": type(e).__name__,
             "message": str(e)
         }
 
 
-def rename_tensor(args):
-    """Rename a tensor."""
+def rename_column(args):
+    """Rename a column."""
     try:
         ds = muller.load(args.path)
 
         with ds:
-            ds.rename_tensor(args.old_name, args.new_name)
+            ds.rename_column(args.old_name, args.new_name)
 
         return {
             "success": True,
-            "operation": "rename_tensor",
+            "operation": "rename_column",
             "result": {
                 "path": args.path,
                 "old_name": args.old_name,
                 "new_name": args.new_name
             },
-            "message": f"Tensor renamed: {args.old_name} -> {args.new_name}"
+            "message": f"Column renamed: {args.old_name} -> {args.new_name}"
         }
     except Exception as e:
         return {
             "success": False,
-            "operation": "rename_tensor",
+            "operation": "rename_column",
             "error": type(e).__name__,
             "message": str(e)
         }
@@ -235,7 +241,8 @@ def main():
     create_parser = subparsers.add_parser("create", help="Create dataset")
     create_parser.add_argument("--path", required=True, help="Dataset path")
     create_parser.add_argument("--overwrite", action="store_true", help="Overwrite existing")
-    create_parser.add_argument("--tensors", help="Tensors: name:htype:compression_or_dtype,...")
+    create_parser.add_argument("--columns", help="Columns: name:htype:compression_or_dtype,...")
+    create_parser.add_argument("--tensors", help=argparse.SUPPRESS)
 
     # Info command
     info_parser = subparsers.add_parser("info", help="Get dataset info")
@@ -250,25 +257,35 @@ def main():
     delete_parser.add_argument("--path", required=True, help="Dataset path")
     delete_parser.add_argument("--large-ok", action="store_true", help="Allow large delete")
 
-    # Create tensor command
-    create_tensor_parser = subparsers.add_parser("create-tensor", help="Create tensor")
-    create_tensor_parser.add_argument("--path", required=True, help="Dataset path")
-    create_tensor_parser.add_argument("--name", required=True, help="Tensor name")
-    create_tensor_parser.add_argument("--htype", default="generic", help="Tensor htype")
-    create_tensor_parser.add_argument("--dtype", help="Data type")
-    create_tensor_parser.add_argument("--compression", help="Sample compression")
+    # Column commands. Legacy tensor command names remain accepted.
+    for command_name, help_text in (
+        ("create-column", "Create column"),
+        ("create-tensor", argparse.SUPPRESS),
+    ):
+        create_column_parser = subparsers.add_parser(command_name, help=help_text)
+        create_column_parser.add_argument("--path", required=True, help="Dataset path")
+        create_column_parser.add_argument("--name", required=True, help="Column name")
+        create_column_parser.add_argument("--htype", default="generic", help="Column htype")
+        create_column_parser.add_argument("--dtype", help="Data type")
+        create_column_parser.add_argument("--compression", help="Sample compression")
 
-    # Delete tensor command
-    delete_tensor_parser = subparsers.add_parser("delete-tensor", help="Delete tensor")
-    delete_tensor_parser.add_argument("--path", required=True, help="Dataset path")
-    delete_tensor_parser.add_argument("--name", required=True, help="Tensor name")
-    delete_tensor_parser.add_argument("--large-ok", action="store_true", help="Allow large delete")
+    for command_name, help_text in (
+        ("delete-column", "Delete column"),
+        ("delete-tensor", argparse.SUPPRESS),
+    ):
+        delete_column_parser = subparsers.add_parser(command_name, help=help_text)
+        delete_column_parser.add_argument("--path", required=True, help="Dataset path")
+        delete_column_parser.add_argument("--name", required=True, help="Column name")
+        delete_column_parser.add_argument("--large-ok", action="store_true", help="Allow large delete")
 
-    # Rename tensor command
-    rename_tensor_parser = subparsers.add_parser("rename-tensor", help="Rename tensor")
-    rename_tensor_parser.add_argument("--path", required=True, help="Dataset path")
-    rename_tensor_parser.add_argument("--old-name", required=True, help="Old tensor name")
-    rename_tensor_parser.add_argument("--new-name", required=True, help="New tensor name")
+    for command_name, help_text in (
+        ("rename-column", "Rename column"),
+        ("rename-tensor", argparse.SUPPRESS),
+    ):
+        rename_column_parser = subparsers.add_parser(command_name, help=help_text)
+        rename_column_parser.add_argument("--path", required=True, help="Dataset path")
+        rename_column_parser.add_argument("--old-name", required=True, help="Old column name")
+        rename_column_parser.add_argument("--new-name", required=True, help="New column name")
 
     args = parser.parse_args()
 
@@ -286,12 +303,12 @@ def main():
         result = get_stats(args)
     elif args.command == "delete":
         result = delete_dataset(args)
-    elif args.command == "create-tensor":
-        result = create_tensor(args)
-    elif args.command == "delete-tensor":
-        result = delete_tensor(args)
-    elif args.command == "rename-tensor":
-        result = rename_tensor(args)
+    elif args.command in ("create-column", "create-tensor"):
+        result = create_column(args)
+    elif args.command in ("delete-column", "delete-tensor"):
+        result = delete_column(args)
+    elif args.command in ("rename-column", "rename-tensor"):
+        result = rename_column(args)
 
     # Output JSON
     print(json.dumps(result, indent=2))

--- a/.claude/skills/muller-export/SKILL.md
+++ b/.claude/skills/muller-export/SKILL.md
@@ -41,7 +41,7 @@ Handles export and format conversion operations.
 - `to-arrow` - Export to Apache Arrow format
 - `to-parquet` - Export to Parquet files
 - `to-json` - Export to JSON format
-- `to-numpy` - Convert tensors to NumPy arrays
+- `to-numpy` - Convert columns to NumPy arrays
 - `to-mindrecord` - Export to MindRecord format
 - `get-info` - Get export information
 
@@ -59,9 +59,9 @@ python3 .claude/skills/muller-export/scripts/export.py to-parquet \
 python3 .claude/skills/muller-export/scripts/export.py to-json \
   --path ./my_dataset --output ./output.json
 
-# Convert tensor to NumPy
+# Convert column to NumPy
 python3 .claude/skills/muller-export/scripts/export.py to-numpy \
-  --path ./my_dataset --tensor embeddings --output ./embeddings.npy
+  --path ./my_dataset --column embeddings --output ./embeddings.npy
 
 # Export to MindRecord
 python3 .claude/skills/muller-export/scripts/export.py to-mindrecord \

--- a/.claude/skills/muller-export/scripts/export.py
+++ b/.claude/skills/muller-export/scripts/export.py
@@ -15,7 +15,7 @@ import os
 import numpy as np
 
 # Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
 
 try:
     import muller
@@ -147,35 +147,37 @@ def export_to_json(args):
 
 
 def export_to_numpy(args):
-    """Convert tensor to NumPy array."""
+    """Convert a column to a NumPy array."""
     try:
         ds = muller.load(args.path, read_only=True)
 
-        if not args.tensor:
+        column = args.column or args.tensor
+        if not column:
             return {
                 "success": False,
                 "operation": "to_numpy",
                 "error": "ValueError",
-                "message": "Tensor name is required for NumPy export"
+                "message": "Column name is required for NumPy export"
             }
 
-        # Get tensor data
-        tensor_data = ds[args.tensor].numpy()
+        # Get column data
+        column_data = ds[column].numpy()
 
         if args.output:
-            np.save(args.output, tensor_data)
+            np.save(args.output, column_data)
 
             return {
                 "success": True,
                 "operation": "to_numpy",
                 "result": {
                     "path": args.path,
-                    "tensor": args.tensor,
+                    "column": column,
+                    "tensor": column,
                     "output": args.output,
-                    "shape": tensor_data.shape,
-                    "dtype": str(tensor_data.dtype)
+                    "shape": column_data.shape,
+                    "dtype": str(column_data.dtype)
                 },
-                "message": f"Exported tensor to NumPy: {args.output}"
+                "message": f"Exported column to NumPy: {args.output}"
             }
         else:
             return {
@@ -183,11 +185,12 @@ def export_to_numpy(args):
                 "operation": "to_numpy",
                 "result": {
                     "path": args.path,
-                    "tensor": args.tensor,
-                    "shape": tensor_data.shape,
-                    "dtype": str(tensor_data.dtype)
+                    "column": column,
+                    "tensor": column,
+                    "shape": column_data.shape,
+                    "dtype": str(column_data.dtype)
                 },
-                "message": "Converted tensor to NumPy (in-memory)"
+                "message": "Converted column to NumPy (in-memory)"
             }
     except Exception as e:
         return {
@@ -237,6 +240,7 @@ def get_export_info(args):
             "result": {
                 "path": args.path,
                 "num_samples": ds.num_samples,
+                "columns": list(ds.columns.keys()),
                 "tensors": list(ds.tensors.keys()),
                 "supported_formats": [
                     "arrow",
@@ -280,9 +284,10 @@ def main():
     to_json_parser.add_argument("--pretty", action="store_true", help="Pretty print")
 
     # To NumPy command
-    to_numpy_parser = subparsers.add_parser("to-numpy", help="Export tensor to NumPy")
+    to_numpy_parser = subparsers.add_parser("to-numpy", help="Export column to NumPy")
     to_numpy_parser.add_argument("--path", required=True, help="Dataset path")
-    to_numpy_parser.add_argument("--tensor", required=True, help="Tensor name")
+    to_numpy_parser.add_argument("--column", help="Column name")
+    to_numpy_parser.add_argument("--tensor", help=argparse.SUPPRESS)
     to_numpy_parser.add_argument("--output", help="Output .npy file")
 
     # To MindRecord command

--- a/.claude/skills/muller-version-control/scripts/version_control.py
+++ b/.claude/skills/muller-version-control/scripts/version_control.py
@@ -14,7 +14,7 @@ import sys
 import os
 
 # Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
 
 try:
     import muller

--- a/README.md
+++ b/README.md
@@ -188,11 +188,13 @@ import muller
 # Create dataset
 ds = muller.dataset(path='test_dataset/', overwrite=True)
 
-# Create tensors (columns)
-ds.create_tensor('my_images', htype='image', sample_compression='jpg')
-ds.create_tensor('labels', htype='generic', dtype='int')
-ds.create_tensor('categories', htype='text')
-ds.create_tensor('description', htype='text')
+# Create columns
+ds.create_column('my_images', htype='image', sample_compression='jpg')
+ds.create_column('labels', htype='generic', dtype='int')
+ds.create_column('categories', htype='text')
+ds.create_column('description', htype='text')
+
+# Backward compatibility: create_tensor/delete_tensor remain supported aliases.
 
 # Append data
 with ds:
@@ -228,15 +230,15 @@ res_3 = ds.filter_vectorized([("description", "CONTAINS", "cat"), ("labels", "<"
 
 # Aggregation
 res_4 = ds.aggregate_vectorized(
-    group_by_tensors=['categories'],
-    selected_tensors=['labels', 'categories'],
-    aggregate_tensors=["*"]
+    group_by_columns=['categories'],
+    selected_columns=['labels', 'categories'],
+    aggregate_columns=["*"]
 )
 
 # Vector similarity search
 import numpy as np
 ds_vec = muller.dataset(path="test_vec/", overwrite=True)
-ds_vec.create_tensor("embeddings", htype="vector", dtype="float32", dimension=32)
+ds_vec.create_column("embeddings", htype="vector", dtype="float32", dimension=32)
 ds_vec.embeddings.extend(np.random.rand(10000, 32).astype(np.float32))
 
 ds_vec.commit()
@@ -244,7 +246,7 @@ ds_vec.create_vector_index("embeddings", index_name="hnsw", index_type="HNSWFLAT
 ds_vec.load_vector_index("embeddings", index_name="hnsw")
 
 query = np.random.rand(100, 32)
-distances, indices = ds_vec.vector_search(query_vector=query, tensor_name="embeddings", index_name="hnsw", topk=10)
+distances, indices = ds_vec.vector_search(query_vector=query, column_name="embeddings", index_name="hnsw", topk=10)
 ```
 
 ### Version Control
@@ -332,7 +334,7 @@ ds.merge("dev-2",
 ```python
 import numpy as np
 ds.checkout("dev-3", create=True)
-ds.create_tensor("features", htype="generic", dtype="float")
+ds.create_column("features", htype="generic", dtype="float")
 ds.features.extend(np.arange(0, 1.1, 0.1))
 ds.commit()
 

--- a/docs/api/dataset-creation.md
+++ b/docs/api/dataset-creation.md
@@ -146,10 +146,10 @@ ds = muller.empty("./datasets/new_dataset", overwrite=True)
 # Create empty dataset on remote storage
 ds = muller.empty("s3://mybucket/new_dataset", creds={"aws_access_key_id": "...", "aws_secret_access_key": "..."})
 
-# Add tensors to the empty dataset
+# Add columns to the empty dataset
 with ds:
-    ds.create_tensor("images")
-    ds.create_tensor("labels")
+    ds.create_column("images")
+    ds.create_column("labels")
 ```
 
 #### Warning
@@ -162,13 +162,13 @@ Setting `overwrite=True` will delete all of your data if it exists!
 
 #### Overview
 
-Copies the source dataset's structure to a new location. No samples are copied, only the meta/info for the dataset and its tensors. This is useful for creating a new dataset with the same schema as an existing one.
+Copies the source dataset's structure to a new location. No samples are copied, only the meta/info for the dataset and its columns. This is useful for creating a new dataset with the same schema as an existing one.
 
 #### Parameters
 
 - **dest** (`str` or `Dataset`): Empty Dataset or Path where the new dataset will be created.
 - **src** (`str` or `Dataset`): Path or dataset object that will be used as the template for the new dataset.
-- **tensors** (`List[str]`, optional): Names of tensors (and groups) to be replicated. If not specified, all tensors in source dataset are considered. Defaults to `None`.
+- **columns** (`List[str]`, optional): Names of columns (and groups) to be replicated. If not specified, all columns in source dataset are considered. The legacy `tensors` keyword remains supported.
 - **overwrite** (`bool`, optional): If `True` and a dataset exists at `dest`, it will be overwritten. Defaults to `False`.
 - **verbose** (`bool`, optional): If `True`, logs will be printed. Defaults to `True`.
 
@@ -188,11 +188,11 @@ new_ds = muller.like(dest="./datasets/new_dataset", src=source_ds)
 # Copy structure from path
 new_ds = muller.like(dest="./datasets/new_dataset", src="./datasets/source_dataset")
 
-# Copy only specific tensors
+# Copy only specific columns
 new_ds = muller.like(
     dest="./datasets/new_dataset",
     src="./datasets/source_dataset",
-    tensors=["images", "labels"]
+    columns=["images", "labels"]
 )
 
 # Overwrite if destination exists
@@ -246,12 +246,12 @@ This operation is irreversible. All data will be permanently deleted.
 
 #### Overview
 
-Get column (tensor) information from a dataset without loading the entire dataset. This is useful for quickly inspecting dataset metadata.
+Get column information from a dataset without loading the entire dataset. This is useful for quickly inspecting dataset metadata.
 
 #### Parameters
 
 - **path** (`str` or `pathlib.Path`): The full path to the dataset.
-- **col_name** (`str`, optional): Name of the column (tensor) to get info for. If `None` or empty string, returns dataset-level info. Defaults to `None`.
+- **col_name** (`str`, optional): Name of the column to get info for. If `None` or empty string, returns dataset-level info. Defaults to `None`.
 
 #### Returns
 
@@ -265,8 +265,8 @@ import muller
 # Get dataset-level info
 info = muller.get_col_info("./datasets/my_dataset")
 
-# Get specific tensor info
-tensor_info = muller.get_col_info("./datasets/my_dataset", col_name="images")
+# Get specific column info
+column_info = muller.get_col_info("./datasets/my_dataset", col_name="images")
 
 # Parse the info (it's in JSON format)
 import json
@@ -448,15 +448,15 @@ ds = muller.from_dataframes(
 
 #### Overview
 
-Create a new dataset from a CSV file. Each CSV column becomes a tensor in the dataset. Columns containing file paths (e.g., image or video files) can be loaded automatically via `muller.read()` using the `path_columns` parameter.
+Create a new dataset from a CSV file. Each CSV column becomes a MULLER column in the dataset. Columns containing file paths (e.g., image or video files) can be loaded automatically via `muller.read()` using the `path_columns` parameter.
 
 #### Parameters
 
 - **csv_path** (`str`): Path to the source CSV file.
 - **muller_path** (`str`): Path where the MULLER dataset will be created.
-- **schema** (`dict`, optional): Schema definition for the dataset. Format: `{column_name: (htype, dtype, sample_compression)}`. If not provided, all columns are created as `generic` tensors. Defaults to `None`.
+- **schema** (`dict`, optional): Schema definition for the dataset. Format: `{column_name: (htype, dtype, sample_compression)}`. If not provided, all columns are created as `generic` columns. Defaults to `None`.
 - **path_columns** (`dict`, optional): Dict mapping column names to their handling mode for file path values. Defaults to `None`.
-  - `"read"`: Calls `muller.read(path)` to load the file as a Sample (for image/video/audio tensors).
+  - `"read"`: Calls `muller.read(path)` to load the file as a Sample (for image/video/audio columns).
   - `"text"`: Stores the file path as a plain text string.
 - **workers** (`int`, optional): Number of workers for parallel processing. Defaults to `0`.
 - **scheduler** (`str`, optional): Scheduler type for compute operations. Defaults to `"processed"`.
@@ -526,7 +526,7 @@ ds = muller.from_csv(
 
 #### Notes
 
-- The CSV file must have a header row. Column names in the header are used as tensor names.
+- The CSV file must have a header row. Column names in the header are used as MULLER column names.
 - All CSV values are read as strings. Use `schema` to specify the correct `htype` and `dtype` for each column.
 - Columns not listed in `path_columns` are appended directly as their raw CSV string values.
 - The `path_columns` parameter is only needed when a CSV column contains file paths that should be loaded as binary data (images, videos, etc.) or explicitly stored as path strings.
@@ -537,7 +537,7 @@ ds = muller.from_csv(
 
 #### Overview
 
-Append data from a CSV file into an existing dataset. Tensors must already be created before calling this method. This is useful for incrementally adding data from CSV files to a dataset that was created manually or from another source.
+Append data from a CSV file into an existing dataset. Columns must already be created before calling this method. This is useful for incrementally adding data from CSV files to a dataset that was created manually or from another source.
 
 #### Parameters
 
@@ -558,17 +558,17 @@ Append data from a CSV file into an existing dataset. Tensors must already be cr
 
 #### Raises
 
-- **ValueError**: If `csv_path` is empty, the CSV file cannot be read, or CSV column names do not match existing tensor names.
+- **ValueError**: If `csv_path` is empty, the CSV file cannot be read, or CSV column names do not match existing column names.
 
 #### Examples
 
 ```python
 import muller
 
-# Create a dataset and define tensors manually
+# Create a dataset and define columns manually
 ds = muller.dataset(path="./datasets/my_dataset", overwrite=True)
-ds.create_tensor("image_path", htype="image", sample_compression="jpeg")
-ds.create_tensor("label", htype="text", sample_compression="lz4")
+ds.create_column("image_path", htype="image", sample_compression="jpeg")
+ds.create_column("label", htype="text", sample_compression="lz4")
 
 # Append data from a CSV file
 ds.add_data_from_csv(
@@ -589,6 +589,6 @@ print(len(ds))  # accumulated samples from both CSV files
 
 #### Notes
 
-- The CSV column names must match the existing tensor names in the dataset. A `ValueError` is raised if they do not match.
+- The CSV column names must match the existing column names in the dataset. A `ValueError` is raised if they do not match.
 - This method can be called multiple times to incrementally append data from different CSV files.
 - The `path_columns` parameter works identically to `muller.from_csv()`.

--- a/docs/api/dataset-export.md
+++ b/docs/api/dataset-export.md
@@ -20,7 +20,7 @@ Convert the dataset to a pandas DataFrame. This is useful for data analysis and 
 
 #### Parameters
 
-- **tensor_list** (`List[str]`, optional): The tensor columns to export. If not provided, all tensors will be exported. Defaults to `None`.
+- **columns** (`List[str]`, optional): The columns to export. If not provided, all columns will be exported. The legacy `tensor_list` keyword remains supported.
 - **index_list** (`List[int]`, optional): The indices of rows to export. If not provided, all rows will be exported. Defaults to `None`.
 - **force** (`bool`, optional): If `True`, exports the dataset regardless of size. Datasets with more than `TO_DATAFRAME_SAFE_LIMIT` samples might take a long time to export. Defaults to `False`.
 
@@ -39,15 +39,15 @@ ds = muller.load("./my_dataset")
 df = ds.to_dataframe()
 print(df.head())
 
-# Export specific tensors
-df = ds.to_dataframe(tensor_list=["images", "labels"])
+# Export specific columns
+df = ds.to_dataframe(columns=["images", "labels"])
 
 # Export specific rows
 df = ds.to_dataframe(index_list=[0, 1, 2, 10, 20])
 
-# Export specific tensors and rows
+# Export specific columns and rows
 df = ds.to_dataframe(
-    tensor_list=["labels", "categories"],
+    columns=["labels", "categories"],
     index_list=[1, 2, 4, 8, 16]
 )
 
@@ -80,7 +80,7 @@ Export the dataset to JSON format. This creates a JSON file or returns JSON data
 #### Parameters
 
 - **path** (`str`, optional): Path where the JSON file will be saved. If not provided, returns JSON string. Defaults to `None`.
-- **tensor_list** (`List[str]`, optional): The tensor columns to export. If not provided, all tensors will be exported. Defaults to `None`.
+- **columns** (`List[str]`, optional): The columns to export. If not provided, all columns will be exported. The legacy `tensors` keyword remains supported.
 - **index_list** (`List[int]`, optional): The indices of rows to export. If not provided, all rows will be exported. Defaults to `None`.
 - **indent** (`int`, optional): Number of spaces for JSON indentation. Defaults to `2`.
 
@@ -98,8 +98,8 @@ ds = muller.load("./my_dataset")
 # Export to JSON file
 ds.to_json("./output/dataset.json")
 
-# Export specific tensors
-ds.to_json("./output/labels_only.json", tensor_list=["labels"])
+# Export specific columns
+ds.to_json("./output/labels_only.json", columns=["labels"])
 
 # Export specific samples
 ds.to_json("./output/sample_subset.json", index_list=[0, 1, 2, 3, 4])
@@ -126,7 +126,7 @@ Convert the dataset to Apache Arrow format. This is useful for interoperability 
 
 #### Parameters
 
-- **tensor_list** (`List[str]`, optional): The tensor columns to export. If not provided, all tensors will be exported. Defaults to `None`.
+- **columns** (`List[str]`, optional): The columns to export. If not provided, all columns will be exported.
 - **index_list** (`List[int]`, optional): The indices of rows to export. If not provided, all rows will be exported. Defaults to `None`.
 
 #### Returns
@@ -144,8 +144,8 @@ ds = muller.load("./my_dataset")
 arrow_table = ds.to_arrow()
 print(arrow_table.schema)
 
-# Export specific tensors
-arrow_table = ds.to_arrow(tensor_list=["labels", "features"])
+# Arrow export includes all columns
+arrow_table = ds.to_arrow()
 
 # Export specific samples
 arrow_table = ds.to_arrow(index_list=range(100))
@@ -176,7 +176,7 @@ Export the dataset to MindRecord format, which is used by MindSpore framework. T
 #### Parameters
 
 - **path** (`str`): Path where the MindRecord files will be saved.
-- **tensor_list** (`List[str]`, optional): The tensor columns to export. If not provided, all tensors will be exported. Defaults to `None`.
+- This method exports all columns.
 - **index_list** (`List[int]`, optional): The indices of rows to export. If not provided, all rows will be exported. Defaults to `None`.
 - **num_shards** (`int`, optional): Number of MindRecord shards to create. Defaults to `1`.
 - **overwrite** (`bool`, optional): If `True`, overwrites existing files. Defaults to `False`.
@@ -198,11 +198,8 @@ ds.to_mindrecord("./output/dataset.mindrecord")
 # Export with multiple shards
 ds.to_mindrecord("./output/dataset.mindrecord", num_shards=8)
 
-# Export specific tensors
-ds.to_mindrecord(
-    "./output/images_labels.mindrecord",
-    tensor_list=["images", "labels"]
-)
+# Export all columns
+ds.to_mindrecord("./output/images_labels.mindrecord")
 
 # Export subset of data
 ds.to_mindrecord(
@@ -238,7 +235,7 @@ Write the dataset to Parquet format. Parquet is a columnar storage format that i
 #### Parameters
 
 - **path** (`str`): Path where the Parquet file(s) will be saved.
-- **tensor_list** (`List[str]`, optional): The tensor columns to export. If not provided, all tensors will be exported. Defaults to `None`.
+- **columns** (`List[str]`, optional): The columns to export. If not provided, all columns will be exported.
 - **index_list** (`List[int]`, optional): The indices of rows to export. If not provided, all rows will be exported. Defaults to `None`.
 - **compression** (`str`, optional): Compression codec to use (e.g., "snappy", "gzip", "brotli"). Defaults to `"snappy"`.
 - **row_group_size** (`int`, optional): Number of rows per row group. Defaults to `None` (automatic).
@@ -260,10 +257,10 @@ ds.write_to_parquet("./output/dataset.parquet")
 # Write with specific compression
 ds.write_to_parquet("./output/dataset.parquet", compression="gzip")
 
-# Write specific tensors
+# Write specific columns
 ds.write_to_parquet(
     "./output/labels_only.parquet",
-    tensor_list=["labels", "categories"]
+    columns=["labels", "categories"]
 )
 
 # Write subset of data

--- a/docs/api/dataset-methods.md
+++ b/docs/api/dataset-methods.md
@@ -1,6 +1,6 @@
 # Dataset Core Methods
 
-This page documents core instance methods for Dataset objects, including data operations, tensor management, cache control, and basic information retrieval.
+This page documents core instance methods for Dataset objects, including data operations, column management, cache control, and basic information retrieval.
 
 ## Table of Contents
 
@@ -10,11 +10,11 @@ This page documents core instance methods for Dataset objects, including data op
 - [ds.update()](#dsupdate)
 - [ds.pop()](#dspop)
 
-### Tensor Management
-- [ds.create_tensor()](#dscreate_tensor)
-- [ds.create_tensor_like()](#dscreate_tensor_like)
-- [ds.delete_tensor()](#dsdelete_tensor)
-- [ds.rename_tensor()](#dsrename_tensor)
+### Column Management
+- [ds.create_column()](#dscreate_column)
+- [ds.create_column_like()](#dscreate_column_like)
+- [ds.delete_column()](#dsdelete_column)
+- [ds.rename_column()](#dsrename_column)
 
 ### Cache and Flush
 - [ds.flush()](#dsflush)
@@ -26,7 +26,7 @@ This page documents core instance methods for Dataset objects, including data op
 - [ds.statistics()](#dsstatistics)
 - [ds.size_approx()](#dssize_approx)
 - [ds.num_samples](#dsnum_samples)
-- [ds.tensors](#dstensors)
+- [ds.columns](#dscolumns)
 
 ---
 
@@ -36,11 +36,11 @@ This page documents core instance methods for Dataset objects, including data op
 
 #### Overview
 
-Append a single sample to the dataset. Each sample is a dictionary where keys are tensor names and values are the data to append.
+Append a single sample to the dataset. Each sample is a dictionary where keys are column names and values are the data to append.
 
 #### Parameters
 
-- **sample** (`Dict[str, Any]`): Dictionary mapping tensor names to their values.
+- **sample** (`Dict[str, Any]`): Dictionary mapping column names to their values.
 - **skip_ok** (`bool`, optional): If `True`, allows skipping samples that cause errors. Defaults to `False`.
 - **append_empty** (`bool`, optional): If `True`, allows appending empty samples. Defaults to `False`.
 
@@ -55,8 +55,8 @@ import muller
 import numpy as np
 
 ds = muller.dataset("./my_dataset", overwrite=True)
-ds.create_tensor("images")
-ds.create_tensor("labels")
+ds.create_column("images")
+ds.create_column("labels")
 
 # Append a single sample
 with ds:
@@ -88,7 +88,7 @@ Extend the dataset with multiple samples at once. This is more efficient than ca
 
 #### Parameters
 
-- **samples** (`Dict[str, Any]`): Dictionary where keys are tensor names and values are lists/arrays of data to append.
+- **samples** (`Dict[str, Any]`): Dictionary where keys are column names and values are lists/arrays of data to append.
 - **skip_ok** (`bool`, optional): If `True`, allows skipping samples that cause errors. Defaults to `False`.
 - **append_empty** (`bool`, optional): If `True`, allows appending empty samples. Defaults to `False`.
 - **ignore_errors** (`bool`, optional): If `True`, continues processing even if errors occur. Defaults to `False`.
@@ -105,8 +105,8 @@ import muller
 import numpy as np
 
 ds = muller.dataset("./my_dataset", overwrite=True)
-ds.create_tensor("images")
-ds.create_tensor("labels")
+ds.create_column("images")
+ds.create_column("labels")
 
 # Extend with multiple samples
 images_data = [np.random.rand(224, 224, 3) for _ in range(100)]
@@ -143,7 +143,7 @@ Update existing samples in the dataset. This modifies data at specific indices.
 
 #### Parameters
 
-- **sample** (`Dict[str, Any]`): Dictionary mapping tensor names to their new values.
+- **sample** (`Dict[str, Any]`): Dictionary mapping column names to their new values.
 
 #### Returns
 
@@ -213,27 +213,27 @@ with ds:
 
 ---
 
-## Tensor Management
+## Column Management
 
-### ds.create_tensor()
+### ds.create_column()
 
 #### Overview
 
-Create a new tensor in the dataset. Tensors are the columns of your dataset, each storing a specific type of data.
+Create a new column in the dataset. Columns store one field of data across samples. The legacy `ds.create_tensor()` method remains supported as a compatibility alias.
 
 #### Parameters
 
-- **name** (`str`): Name of the tensor to create.
-- **htype** (`str`, optional): The htype (high-level type) of the tensor (e.g., "image", "class_label", "text"). If not specified, defaults to "generic".
-- **dtype** (`str` or `np.dtype`, optional): The numpy dtype of the tensor data. If not specified, it's inferred from htype.
+- **name** (`str`): Name of the column to create.
+- **htype** (`str`, optional): The htype (high-level type) of the column (e.g., "image", "class_label", "text"). If not specified, defaults to "generic".
+- **dtype** (`str` or `np.dtype`, optional): The numpy dtype of the column data. If not specified, it's inferred from htype.
 - **sample_compression** (`str`, optional): Compression to apply to each sample (e.g., "jpeg", "png"). Defaults to `None`.
 - **chunk_compression** (`str`, optional): Compression to apply to chunks. Defaults to `None`.
-- **hidden** (`bool`, optional): If `True`, creates a hidden tensor. Defaults to `False`.
-- **kwargs**: Additional keyword arguments for tensor configuration.
+- **hidden** (`bool`, optional): If `True`, creates a hidden column. Defaults to `False`.
+- **kwargs**: Additional keyword arguments for column configuration.
 
 #### Returns
 
-- **Tensor**: The created tensor object.
+- **Tensor**: The created column object. Internally, MULLER still uses the `Tensor` class for storage compatibility.
 
 #### Examples
 
@@ -242,41 +242,41 @@ import muller
 
 ds = muller.dataset("./my_dataset", overwrite=True)
 
-# Create a generic tensor
-ds.create_tensor("data")
+# Create a generic column
+ds.create_column("data")
 
-# Create an image tensor with JPEG compression
-ds.create_tensor("images", htype="image", sample_compression="jpeg")
+# Create an image column with JPEG compression
+ds.create_column("images", htype="image", sample_compression="jpeg")
 
-# Create a text tensor
-ds.create_tensor("descriptions", htype="text", dtype="str")
+# Create a text column
+ds.create_column("descriptions", htype="text", dtype="str")
 
-# Create a class label tensor
-ds.create_tensor("labels", htype="class_label", dtype="int32")
+# Create a class label column
+ds.create_column("labels", htype="class_label", dtype="int32")
 
-# Create a bounding box tensor
-ds.create_tensor("boxes", htype="bbox", dtype="float32")
+# Create a bounding box column
+ds.create_column("boxes", htype="bbox", dtype="float32")
 
 # Create with chunk compression
-ds.create_tensor("embeddings", htype="embedding", chunk_compression="lz4")
+ds.create_column("embeddings", htype="embedding", chunk_compression="lz4")
 ```
 
 ---
 
-### ds.create_tensor_like()
+### ds.create_column_like()
 
 #### Overview
 
-Create a new tensor by copying the metadata and configuration from an existing tensor. No samples are copied, only the structure.
+Create a new column by copying the metadata and configuration from an existing column. No samples are copied, only the structure. The legacy `ds.create_tensor_like()` method remains supported.
 
 #### Parameters
 
-- **name** (`str`): Name of the new tensor to create.
-- **source** (`Tensor`): The source tensor to copy metadata from.
+- **name** (`str`): Name of the new column to create.
+- **source** (`Tensor`): The source column to copy metadata from.
 
 #### Returns
 
-- **Tensor**: The created tensor object.
+- **Tensor**: The created column object.
 
 #### Examples
 
@@ -289,28 +289,28 @@ source_ds = muller.load("./source_dataset")
 # Create new dataset with similar structure
 new_ds = muller.dataset("./new_dataset", overwrite=True)
 
-# Create tensor with same configuration as source
+# Create columns with the same configuration as source
 with new_ds:
-    new_ds.create_tensor_like("images", source_ds["images"])
-    new_ds.create_tensor_like("labels", source_ds["labels"])
+    new_ds.create_column_like("images", source_ds["images"])
+    new_ds.create_column_like("labels", source_ds["labels"])
 
-# Copy tensor structure within same dataset
+# Copy column structure within same dataset
 with new_ds:
-    new_ds.create_tensor_like("images_copy", new_ds["images"])
+    new_ds.create_column_like("images_copy", new_ds["images"])
 ```
 
 ---
 
-### ds.delete_tensor()
+### ds.delete_column()
 
 #### Overview
 
-Delete a tensor from the dataset. This permanently removes the tensor and all its data.
+Delete a column from the dataset. This permanently removes the column and all its data. The legacy `ds.delete_tensor()` method remains supported.
 
 #### Parameters
 
-- **name** (`str`): Name of the tensor to delete.
-- **large_ok** (`bool`, optional): If `True`, allows deletion of large tensors. Defaults to `False`.
+- **name** (`str`): Name of the column to delete.
+- **large_ok** (`bool`, optional): If `True`, allows deletion of large columns. Defaults to `False`.
 
 #### Returns
 
@@ -323,36 +323,36 @@ import muller
 
 ds = muller.load("./my_dataset")
 
-# Delete a tensor
+# Delete a column
 with ds:
-    ds.delete_tensor("old_tensor")
+    ds.delete_column("old_column")
 
-# Delete a large tensor
+# Delete a large column
 with ds:
-    ds.delete_tensor("large_tensor", large_ok=True)
+    ds.delete_column("large_column", large_ok=True)
 
-# Delete multiple tensors
+# Delete multiple columns
 with ds:
-    for tensor_name in ["temp1", "temp2", "temp3"]:
-        ds.delete_tensor(tensor_name)
+    for column_name in ["temp1", "temp2", "temp3"]:
+        ds.delete_column(column_name)
 ```
 
 #### Warning
 
-This operation is irreversible. All data in the tensor will be permanently deleted.
+This operation is irreversible. All data in the column will be permanently deleted.
 
 ---
 
-### ds.rename_tensor()
+### ds.rename_column()
 
 #### Overview
 
-Rename a tensor in the dataset.
+Rename a column in the dataset. The legacy `ds.rename_tensor()` method remains supported.
 
 #### Parameters
 
-- **name** (`str`): Current name of the tensor.
-- **new_name** (`str`): New name for the tensor.
+- **name** (`str`): Current name of the column.
+- **new_name** (`str`): New name for the column.
 
 #### Returns
 
@@ -365,14 +365,14 @@ import muller
 
 ds = muller.load("./my_dataset")
 
-# Rename a tensor
+# Rename a column
 with ds:
-    ds.rename_tensor("old_name", "new_name")
+    ds.rename_column("old_name", "new_name")
 
-# Rename multiple tensors
+# Rename multiple columns
 with ds:
-    ds.rename_tensor("img", "images")
-    ds.rename_tensor("lbl", "labels")
+    ds.rename_column("img", "images")
+    ds.rename_column("lbl", "labels")
 ```
 
 ---
@@ -451,7 +451,7 @@ with ds:
 
 #### Overview
 
-Display a summary of the dataset including tensor names, shapes, dtypes, and sample counts.
+Display a summary of the dataset including column names, shapes, dtypes, and sample counts.
 
 #### Parameters
 
@@ -478,9 +478,9 @@ ds.summary(force=True)
 #### Example Output
 
 ```
-Dataset(path='./my_dataset', tensors=['images', 'labels'])
+Dataset(path='./my_dataset', columns=['images', 'labels'])
 
-  tensor      htype        shape       dtype  compression
+  column      htype        shape       dtype  compression
  -------    --------    ----------    -------  -----------
   images     image     (224, 224, 3)   uint8      jpeg
   labels   class_label      ()         int32      None
@@ -620,15 +620,15 @@ if ds.num_samples == 0:
 
 ---
 
-### ds.tensors
+### ds.columns
 
 #### Overview
 
-Property that returns a dictionary of all tensors in the dataset.
+Property that returns a dictionary of all user-visible columns in the dataset. The legacy `ds.tensors` property remains supported as a compatibility alias.
 
 #### Type
 
-- **Dict[str, Tensor]**: Dictionary mapping tensor names to Tensor objects.
+- **Dict[str, Tensor]**: Dictionary mapping column names to column objects. Internally, these objects still use the `Tensor` class.
 
 #### Examples
 
@@ -637,19 +637,19 @@ import muller
 
 ds = muller.load("./my_dataset")
 
-# Get all tensor names
-tensor_names = list(ds.tensors.keys())
-print(f"Tensors: {tensor_names}")
+# Get all column names
+column_names = list(ds.columns.keys())
+print(f"Columns: {column_names}")
 
-# Iterate over tensors
-for name, tensor in ds.tensors.items():
-    print(f"{name}: {tensor.shape}, {tensor.dtype}")
+# Iterate over columns
+for name, column in ds.columns.items():
+    print(f"{name}: {column.shape}, {column.dtype}")
 
-# Access specific tensor
-images_tensor = ds.tensors["images"]
-print(images_tensor.meta)
+# Access specific column
+images_column = ds.columns["images"]
+print(images_column.meta)
 
-# Check if tensor exists
-if "labels" in ds.tensors:
-    print("Labels tensor exists")
+# Check if column exists
+if "labels" in ds.columns:
+    print("Labels column exists")
 ```

--- a/docs/api/dataset-query.md
+++ b/docs/api/dataset-query.md
@@ -89,11 +89,11 @@ for sample in filtered_ds:
 
 #### Overview
 
-Filter the dataset using vectorized operations for better performance. This method is optimized for large datasets and uses indexed tensors.
+Filter the dataset using vectorized operations for better performance. This method is optimized for large datasets and uses indexed columns.
 
 #### Parameters
 
-- **expression** (`str`): Filter expression using tensor names.
+- **expression** (`str`): Filter expression using column names.
 - **scheduler** (`str`, optional): Scheduler type for parallel processing. Defaults to `"threaded"`.
 - **num_workers** (`int`, optional): Number of workers for parallel processing. Defaults to `0`.
 
@@ -117,7 +117,7 @@ filtered_ds = ds.filter_vectorized("score > 80", num_workers=4)
 # Complex expressions
 filtered_ds = ds.filter_vectorized("(age >= 18) & (age <= 65)")
 
-# Filter on indexed tensors for best performance
+# Filter on indexed columns for best performance
 ds.create_index("labels")
 filtered_ds = ds.filter_vectorized("labels == 3")
 ```
@@ -128,11 +128,11 @@ filtered_ds = ds.filter_vectorized("labels == 3")
 
 #### Overview
 
-Query a specific tensor using a query expression. This is useful for searching within a single tensor.
+Query a specific column using a query expression. This is useful for searching within a single column.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor to query.
+- **column_name** (`str`): Name of the column to query. The legacy `tensor_name` keyword remains supported.
 - **query** (`str`): Query expression.
 
 #### Returns
@@ -146,13 +146,13 @@ import muller
 
 ds = muller.load("./my_dataset")
 
-# Query a specific tensor
+# Query a specific column
 result = ds.query("labels", "value == 5")
 
 # Query with range
 result = ds.query("age", "value >= 18 and value <= 65")
 
-# Query text tensor
+# Query text column
 result = ds.query("description", "value.contains('important')")
 
 # Access query results
@@ -166,12 +166,12 @@ for sample in result:
 
 #### Overview
 
-Perform vector similarity search on a tensor with a vector index. This is useful for finding similar embeddings or features.
+Perform vector similarity search on a column with a vector index. This is useful for finding similar embeddings or features.
 
 #### Parameters
 
 - **query_vector** (`np.ndarray` or `Tensor`): The query vector to search for.
-- **tensor_name** (`str`): Name of the tensor to search in.
+- **column_name** (`str`): Name of the column to search in. The legacy `tensor_name` keyword remains supported.
 - **index_name** (`str`): Name of the vector index to use.
 - **k** (`int`, optional): Number of nearest neighbors to return. Defaults to `10`.
 - **kwargs**: Additional arguments passed to the vector search backend.
@@ -195,7 +195,7 @@ ds.create_vector_index("embeddings", index_name="emb_idx")
 query_vec = np.random.rand(512)
 results = ds.vector_search(
     query_vector=query_vec,
-    tensor_name="embeddings",
+    column_name="embeddings",
     index_name="emb_idx",
     k=10
 )
@@ -208,7 +208,7 @@ for i, sample in enumerate(results):
 # Search with additional parameters
 results = ds.vector_search(
     query_vector=query_vec,
-    tensor_name="embeddings",
+    column_name="embeddings",
     index_name="emb_idx",
     k=20,
     metric="cosine"
@@ -223,11 +223,11 @@ results = ds.vector_search(
 
 #### Overview
 
-Create an index on a tensor to speed up filtering and querying operations.
+Create an index on a column to speed up filtering and querying operations.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor to index.
+- **column_name** (`str`): Name of the column to index.
 - **index_type** (`str`, optional): Type of index to create. Defaults to `"hash"`.
 
 #### Returns
@@ -241,17 +241,17 @@ import muller
 
 ds = muller.load("./my_dataset")
 
-# Create index on labels tensor
+# Create index on labels column
 ds.create_index("labels")
 
 # Create index with specific type
 ds.create_index("categories", index_type="hash")
 
-# Create indexes on multiple tensors
-for tensor_name in ["labels", "categories", "user_id"]:
-    ds.create_index(tensor_name)
+# Create indexes on multiple columns
+for column_name in ["labels", "categories", "user_id"]:
+    ds.create_index(column_name)
 
-# Use indexed tensor for faster filtering
+# Use indexed column for faster filtering
 ds.create_index("labels")
 filtered = ds.filter_vectorized("labels == 5")  # Much faster with index
 ```
@@ -266,7 +266,7 @@ Create an index optimized for vectorized operations. This is useful for large-sc
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor to index.
+- **column_name** (`str`): Name of the column to index.
 - **num_workers** (`int`, optional): Number of workers for parallel index creation. Defaults to `0`.
 - **scheduler** (`str`, optional): Scheduler type. Defaults to `"threaded"`.
 
@@ -287,9 +287,9 @@ ds.create_index_vectorized("labels")
 # Create with multiple workers for faster indexing
 ds.create_index_vectorized("categories", num_workers=4)
 
-# Create vectorized indexes on multiple tensors
-for tensor_name in ["labels", "user_id", "timestamp"]:
-    ds.create_index_vectorized(tensor_name, num_workers=4)
+# Create vectorized indexes on multiple columns
+for column_name in ["labels", "user_id", "timestamp"]:
+    ds.create_index_vectorized(column_name, num_workers=4)
 ```
 
 ---
@@ -302,7 +302,7 @@ Optimize an existing index to improve query performance. This reorganizes the in
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor whose index to optimize.
+- **column_name** (`str`): Name of the column whose index to optimize.
 
 #### Returns
 
@@ -319,8 +319,8 @@ ds = muller.load("./my_dataset")
 ds.optimize_index("labels")
 
 # Optimize all indexes
-for tensor_name in ds.indexed_tensors:
-    ds.optimize_index(tensor_name)
+for column_name in ds.indexed_columns:
+    ds.optimize_index(column_name)
 ```
 
 ---
@@ -329,11 +329,11 @@ for tensor_name in ds.indexed_tensors:
 
 #### Overview
 
-Create a vector index for similarity search on embedding tensors. This enables fast nearest neighbor search.
+Create a vector index for similarity search on embedding columns. This enables fast nearest neighbor search.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor containing vectors/embeddings.
+- **column_name** (`str`): Name of the column containing vectors/embeddings. The legacy `tensor_name` keyword remains supported.
 - **index_name** (`str`): Name for the vector index.
 - **index_type** (`str`, optional): Type of vector index (e.g., "HNSW", "IVF"). Defaults to `"HNSW"`.
 - **metric** (`str`, optional): Distance metric (e.g., "cosine", "euclidean"). Defaults to `"cosine"`.
@@ -377,11 +377,11 @@ ds.create_vector_index(
 
 #### Overview
 
-Delete a vector index from a tensor.
+Delete a vector index from a column.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor.
+- **column_name** (`str`): Name of the column. The legacy `tensor_name` keyword remains supported.
 - **index_name** (`str`): Name of the vector index to drop.
 
 #### Returns
@@ -413,7 +413,7 @@ Update a vector index after adding new samples to the dataset.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor.
+- **column_name** (`str`): Name of the column. The legacy `tensor_name` keyword remains supported.
 - **index_name** (`str`): Name of the vector index to update.
 
 #### Returns
@@ -450,7 +450,7 @@ Load a vector index into memory for faster search operations.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor.
+- **column_name** (`str`): Name of the column. The legacy `tensor_name` keyword remains supported.
 - **index_name** (`str`): Name of the vector index to load.
 
 #### Returns
@@ -482,7 +482,7 @@ Unload a vector index from memory to free up resources.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor.
+- **column_name** (`str`): Name of the column. The legacy `tensor_name` keyword remains supported.
 - **index_name** (`str`): Name of the vector index to unload.
 
 #### Returns
@@ -513,7 +513,7 @@ Create a hot shard index for frequently accessed data. This optimizes access pat
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor to create hot shard index for.
+- **column_name** (`str`): Name of the column to create hot shard index for.
 - **shard_size** (`int`, optional): Size of each shard. Defaults to automatic calculation.
 
 #### Returns
@@ -544,7 +544,7 @@ Reorganize index shards for better performance. This is useful after significant
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor whose index to reshard.
+- **column_name** (`str`): Name of the column whose index to reshard.
 - **num_shards** (`int`, optional): Target number of shards. Defaults to automatic calculation.
 
 #### Returns

--- a/docs/getting_started/2_create_muller_dataset.md
+++ b/docs/getting_started/2_create_muller_dataset.md
@@ -49,19 +49,19 @@ The usage is similar to the examples above; simply add the appropriate path pref
 * If the path specified by `path` already contains an existing MULLER dataset, a `DatasetHandlerError` will be raised. You may set `overwrite=True` to explicitly overwrite the existing dataset.
 * For additional optional arguments and advanced usage of these APIs, please refer to the API documentation: [`muller.empty()`](../api/dataset-creation/#mullerempty) and [`muller.dataset()`](../api/dataset-creation/#mullerdataset).
 
-### Step 2. Create Tensor Columns and Specify Column Types
+### Step 2. Create Columns and Specify Column Types
 
-In a MULLER dataset, columns are referred to as **tensor columns**.  
-MULLER adopts a column-oriented storage layout, where each tensor column can be configured with a specific column type (`htype`), sample compression format (`sample_compression`), and data type (`dtype`).
+In a MULLER dataset, data is organized as **columns**.  
+MULLER adopts a column-oriented storage layout, where each column can be configured with a specific column type (`htype`), sample compression format (`sample_compression`), and data type (`dtype`). Older `tensor` APIs such as `create_tensor()` remain supported as compatibility aliases.
 
 For most column types, specifying an appropriate compression format can significantly reduce storage footprint and improve read performance.
 
 ```python
 >>> ds = muller.dataset(path='my_muller_dataset/', overwrite=True)  # Create a new MULLER dataset
->>> ds.create_tensor(name='my_text', htype='text')
->>> ds.create_tensor(name='my_photos', htype='image', sample_compression='jpg')
+>>> ds.create_column(name='my_text', htype='text')
+>>> ds.create_column(name='my_photos', htype='image', sample_compression='jpg')
 >>> ds.summary()  # Inspect the dataset schema
-  tensor      htype     shape     dtype   compression
+  column      htype     shape     dtype   compression
   -------    -------   -------   -------  -----------
   my_text     text      (0,)      str      None
   my_photos   image     (0,)      uint8    jpeg
@@ -70,15 +70,15 @@ For the `generic` column type, the data type (`dtype`) can be explicitly specifi
 For other column types, the `dtype` is predefined and does not need to be specified.
 
 ```python
->>> ds.create_tensor(name='my_label', htype='generic', dtype='int32')
+>>> ds.create_column(name='my_label', htype='generic', dtype='int32')
 >>> ds.summary()
-  tensor      htype     shape     dtype   compression
+  column      htype     shape     dtype   compression
   -------    -------   -------   -------  -----------
   my_text     text      (0,)      str      None
   my_photos   image     (0,)      uint8    jpeg
   my_label    generic   (0,)      int32    None
 ```
-Currently, MULLER supports the following tensor column types (`htype`), compression formats (`sample_compression`), and default data types (`dtype`). For detailed information about each htype, see the [Htypes Reference](../api/htypes/).
+Currently, MULLER supports the following column types (`htype`), compression formats (`sample_compression`), and default data types (`dtype`). For detailed information about each htype, see the [Htypes Reference](../api/htypes/).
 
 | htype | sample_compression | dtype |
 | --- | --- | --- |
@@ -93,18 +93,18 @@ Currently, MULLER supports the following tensor column types (`htype`), compress
 | vector  | Default: None (null); Optional: lz4 | Default:  `float32` |
 | generic  | Default: None (null); Optional: lz4 | Default: None (undeclared, inferred from data); Declaration at creation is recommended.<br>Options: `int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, <br>`uint32`, `float32`, `float64`, `bool` |
 
-- **Note 1:** If `htype` is not specified when creating a tensor column, it defaults to `generic`.
+- **Note 1:** If `htype` is not specified when creating a column, it defaults to `generic`.
 - **Note 2:** For `class_label`, `bbox`, `text`, `json`, `list`, and `generic` columns, it is recommended to leave `sample_compression` as `None` unless storage savings are critical. Using `lz4` introduces additional compression and decompression overhead, which may negatively impact read and write performance.
-- **Note 3:** In addition to `htype`, `sample_compression`, and `dtype`, additional parameters can be specified when creating tensor columns for advanced use cases, such as [`chunk_compression`](../api/dataset-methods/#create_tensor) for chunk-level compression, and `coords` for `bbox` columns. Refer to the [`create_tensor()`](../api/dataset-methods/#create_tensor) API documentation and [Htypes Reference](../api/htypes/) for details.
-- **Note 4:** Tensor column names must not contain any MULLER reserved keywords or any Python reserved keywords.
+- **Note 3:** In addition to `htype`, `sample_compression`, and `dtype`, additional parameters can be specified when creating columns for advanced use cases, such as [`chunk_compression`](../api/dataset-methods/#dscreate_column) for chunk-level compression, and `coords` for `bbox` columns. Refer to the [`create_column()`](../api/dataset-methods/#dscreate_column) API documentation and [Htypes Reference](../api/htypes/) for details.
+- **Note 4:** Column names must not contain any MULLER reserved keywords or any Python reserved keywords.
   ```
   keyword_list_1 = ['__bool__', '__class__', '__del__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__getitem__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__iter__', '__le__', '__len__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setitem__', '__setstate__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_all_tensors_filtered', '_append_or_extend', '_append_to_queries_json', '_check_values', '_checkout', '_checkout_hooks', '_client', '_commit', '_commit_hooks', '_copy', '_create_downsampled_tensor', '_create_sample_id_tensor', '_create_sample_info_tensor', '_create_sample_shape_tensor', '_create_tensor', '_dataset_diff', '_delete_branch', '_delete_tensor', '_deserialize_uuids', '_disable_padding', '_ds_diff', '_enable_padding', '_find_subtree', '_first_load_init', '_flush_vc_info', '_get_chunk_names', '_get_commit_id_for_address', '_get_empty_vds', '_get_inverted_index', '_get_tensor_from_root', '_get_tensor_uuids', '_get_view', '_get_view_info', '_groups', '_groups_filtered', '_has_group_in_root', '_indexing_history', '_info', '_initial_autoflush', '_inverted_index', '_is_filtered_view', '_is_root', '_link_tensors', '_load_link_creds', '_load_version_info', '_lock', '_lock_lost_handler', '_lock_queries_json', '_lock_timeout', '_locked_out', '_locking_enabled', '_pad_tensors', '_parent_dataset', '_pop', '_populate_meta', '_query_string', '_read_from_upper_cache', '_read_only', '_read_only_error', '_read_queries_json', '_register_dataset', '_reload_version_state', '_resolve_tensor_list', '_sample_indices', '_save_view', '_save_view_in_path', '_save_view_in_subdir', '_send_branch_creation_event', '_send_branch_deletion_event', '_send_commit_event', '_send_compute_progress', '_send_query_progress', '_set_derived_attributes', '_set_read_only', '_sub_ds', '_subtree_to_dict', '_temp_tensors', '_tensors', '_token', '_ungrouped_tensors', '_unlock', '_update_hooks', '_update_upper_cache', '_vc_info_updated', '_view_base', '_view_hash', '_view_id', '_view_use_parent_commit', '_write_queries_json', '_write_vds', 'add_data', 'add_data_from_dataframes', 'add_data_from_file', 'aggregate', 'append', 'base_storage', 'branch', 'branches', 'checkout', 'client', 'commit', 'commit_id', 'commits', 'commits_between', 'create_index', 'create_tensor', 'create_tensor_like', 'delete', 'delete_branch', 'delete_tensor', 'delete_view', 'diff', 'ds_name', 'enabled_tensors', 'extend', 'filter', 'filter_next', 'filtered_index', 'flush', 'generate_add_update_value', 'get_children_nodes', 'get_commit_details', 'get_view', 'get_views', 'group_index', 'groups', 'has_head_changes', 'index', 'indexed_tensors', 'info', 'is_first_load', 'is_head_node', 'is_iteration', 'is_optimized', 'is_view', 'libgtnf_dataset', 'link_creds', 'load_view', 'log', 'max_len', 'max_view', 'maybe_flush', 'merge', 'meta', 'min_len', 'min_view', 'no_view_dataset', 'num_samples', 'numpy', 'org_id', 'pad_tensors', 'parent', 'parse_changes', 'path', 'pending_commit_id', 'pop', 'public', 'query', 'read_only', 'rechunk', 'rename', 'reset', 'root', 'sample_indices', 'save_as_branch', 'save_view', 'set_token', 'size_approx', 'split_tensor_meta', 'statistics', 'storage', 'summary', 'tensors', 'to_arrow', 'to_json', 'to_mindrecord', 'token', 'update', 'username', 'verbose', 'version_state', 'write_to_parquet']
   keyword_list_2 = ['__class__', '__class_getitem__', '__contains__', '__delattr__', '__delitem__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__ior__', '__iter__', '__le__', '__len__', '__lt__', '__ne__', '__new__', '__or__', '__reduce__', '__reduce_ex__', '__repr__', '__reversed__', '__ror__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__subclasshook__', 'clear', 'copy', 'fromkeys', 'get', 'items', 'keys', 'pop', 'popitem', 'setdefault', 'update', 'values']
   attr_and_keyword_list_3 = ['tensors', 'data', 'all_chunk_engines', 'group_index', 'cache_size', 'cache_used' 'idx',  'pg_callback', 'start_input_idx', '_client', 'path', 'storage', '_read_only_error', 'base_storage', '_read_only',  '_locked_out', 'is_iteration', 'is_first_load', '_is_filtered_view', 'index', 'group_index', 'version_state', 'pad_tensors', '_locking_enabled', '_lock_timeout', '_temp_tensors', '_commit_hooks', '_checkout_hooks', 'public', 'verbose', '_vc_info_updated', '_info', '_ds_diff', 'enabled_tensors', 'link_creds', '_update_hooks', '_view_id', '_view_base', '_view_use_parent_commit', '_pad_tensors', 'libgtnf_dataset', '_parent_dataset', '_query_string', '_inverted_index', 'filtered_index', 'split_tensor_meta', 'creds', '_vector_index', 'append_only', '_initial_autoflush', '_indexing_history', 'read_only', 'is_first_load']
   ```
-- For more detailed usage, please refer to [`create_tensor()`](../api/dataset-methods/#create_tensor). We plan to support additional `htype`s and provide clearer guidelines for tensor column creation in future releases. This documentation will be updated accordingly.
+- For more detailed usage, please refer to [`create_column()`](../api/dataset-methods/#dscreate_column). We plan to support additional `htype`s and provide clearer guidelines for column creation in future releases. This documentation will be updated accordingly.
 
-### Step 3. Append Data to Tensor Columns
+### Step 3. Append Data to Columns
 
 #### 3.1. Appending a small number of samples (recommended: default single-process mode)
 

--- a/docs/getting_started/3_muller_dataset_operations(load,append,update,delete,query).md
+++ b/docs/getting_started/3_muller_dataset_operations(load,append,update,delete,query).md
@@ -66,8 +66,8 @@ APIs for inspecting detailed tensor (column) metadata include:
 
 ## 3. Adding Data
 
-Data can be appended to tensor columns using the same APIs and workflows
-described in Section 3.1 (Step 3: Adding Data to Tensor Columns).
+Data can be appended to columns using the same APIs and workflows
+described in Section 3.1 (Step 3: Adding Data to Columns).
 
 ## 4. Deleting Samples or Datasets
 
@@ -83,15 +83,15 @@ described in Section 3.1 (Step 3: Adding Data to Tensor Columns).
 >>> ds.pop([1, 2, 4, 5])  # Removes samples at indices [1, 2, 4, 5]
 ```
 
-#### Deleting a tensor column and all of its data:
+#### Deleting a column and all of its data:
 
 ```python
->>> ds.delete_tensor(<tensor_name>)
+>>> ds.delete_column(<column_name>)
 # Note: `large_ok` defaults to False. When deleting a column with a large
 # number of samples, set `large_ok=True` to explicitly confirm the operation
 # and prevent accidental data loss.
 ```
-- For detailed usage, see [`pop()`](../api/dataset-methods/#pop) and [`delete_tensor()`](../api/dataset-methods/#delete_tensor).
+- For detailed usage, see [`pop()`](../api/dataset-methods/#pop) and [`delete_column()`](../api/dataset-methods/#dsdelete_column). The legacy `delete_tensor()` name is still supported.
 - **Note:** To ensure dataset integrity, data can only be deleted **by entire rows or entire columns**.
 
 #### Deleting a dataset (Method 1):
@@ -109,10 +109,10 @@ For a dataset that is not currently loaded, you can delete it using the `muller`
 
 ## 5. Inspecting Data by random access (via row id and column name) and full scan
 
-#### Access the i-th row in a tensor column (first access the column, then the row):
+#### Access the i-th row in a column (first access the column, then the row):
 
 ```python
->>> ds.tensors
+>>> ds.columns
 {'my_label': Tensor(key='my_label'),
  'my_photos': Tensor(key='my_photos'),
  'my_text': Tensor(key='my_text')}
@@ -127,7 +127,7 @@ array([1], dtype=int32)
 b'\x01\x00\x00\x00'
 ```
 
-#### Access multiple rows of in tensor column (first access the column, then the row):
+#### Access multiple rows in a column (first access the column, then the row):
 ```python
 >>> ds.my_label[1:4].numpy()   # Returns the sample as a NumPy array
 array([[2],

--- a/docs/getting_started/4_muller_version_control.md
+++ b/docs/getting_started/4_muller_version_control.md
@@ -8,11 +8,11 @@ Below are several key commands.
 
 After performing write operations (add/delete/update), call `ds.commit()` to create a new version (commit ID).
 
-Example: load a dataset, create a tensor column, and commit.
+Example: load a dataset, create a column, and commit.
 
 ```python
 >>> ds = muller.dataset("/data/muller_exp/", overwrite=True)
->>> ds.create_tensor(name="labels", htype="generic", dtype="int")
+>>> ds.create_column(name="labels", htype="generic", dtype="int")
 >>> first_commit_id = ds.commit(message="first commit.")
 >>> first_commit_id
 'firstdbf9474d461a19e9333c2fd19b46115348f'
@@ -37,11 +37,11 @@ Create a new branch with `create=True`:
 
 ```python
 >>> ds.checkout("dev", create=True)
->>> ds.create_tensor("categories", htype="text")
+>>> ds.create_column("categories", htype="text")
 >>> ds.categories.extend(["agent", "emotion", "generation", "writing", "emotion"])
->>> ds.commit("created categories tensor column and add values.")
->>> ds.summary()  # Now dev has two tensor columns (categories and labels).
-tensor     htype    shape    dtype  compression
+>>> ds.commit("created categories column and add values.")
+>>> ds.summary()  # Now dev has two columns (categories and labels).
+column     htype    shape    dtype  compression
  -------    -------  -------  -------  -------
 categories   text    (5, 1)     str     None
   labels    generic  (5, 1)    int64    None
@@ -53,8 +53,8 @@ Switch to an existing branch:
 >>> ds.checkout("main")  # Switch back to main.
 >>> ds.branch            # Check the current branch name.
 'main'
->>> ds.summary()         # This branch has only one tensor column (labels).
-tensor    htype    shape    dtype  compression
+>>> ds.summary()         # This branch has only one column (labels).
+column    htype    shape    dtype  compression
 -------  -------  -------  -------  -------
 labels   generic  (5, 1)    int64    None
 ```
@@ -97,7 +97,7 @@ Current Branch: dev
 Commit : 476be1766915dfe652f39e39f5370f9c04528df9 (dev)
 Author : public
 Time   : 2025-02-28 08:07:48
-Message: created categories tensor column and add values.
+Message: created categories column and add values.
 
 Commit : 637adeb5232f0152b866c9a2a49e8da19f00c1da (main)
 Author : public
@@ -123,7 +123,7 @@ Message: first commit.
 
 ### 4. Direct Diff (available in v0.6.10+)
 
-Understanding changes between versions is critical. MULLER provides `ds.direct_diff(id_1, id_2)` to compute the *direct* per-tensor, per-row differences between `id_1` and `id_2` (in the direction “from `id_1` to `id_2`”). It can optionally return a pandas DataFrame for inspection.
+Understanding changes between versions is critical. MULLER provides `ds.direct_diff(id_1, id_2)` to compute the *direct* per-column, per-row differences between `id_1` and `id_2` (in the direction “from `id_1` to `id_2`”). It can optionally return a pandas DataFrame for inspection.
 
 Parameters (note that the order matters):
 
@@ -139,9 +139,9 @@ import muller
 
 ds = muller.dataset(path="temp_test", overwrite=True)
 
-ds.create_tensor(name="labels", htype="generic", dtype="int")
-ds.create_tensor(name="categories", htype="text")
-ds.create_tensor(name="test1", htype="generic", dtype="int")
+ds.create_column(name="labels", htype="generic", dtype="int")
+ds.create_column(name="categories", htype="text")
+ds.create_column(name="test1", htype="generic", dtype="int")
 ds.labels.extend([0, 1, 2, 3, 4])
 ds.categories.extend(["a", "b", "c", "d", "e"])
 ds.test1.extend([100, 101, 102, 103, 104])
@@ -157,13 +157,13 @@ dev_1 = ds.commit("first on dev")
 
 ds.checkout("main", create=False)
 ds.checkout("dev_2", create=True)
-ds.delete_tensor("test1")
+ds.delete_column("test1")
 ds.labels.extend([5, 6])
 ds.categories.extend(["f", "g"])
 ds.commit("first on dev_2")
 ds.labels[1] = 111
 ds.categories[1] = "xixixi"
-ds.create_tensor(name="test2", htype="generic", dtype="int")
+ds.create_column(name="test2", htype="generic", dtype="int")
 ds.test2.extend([100, 101, 102, 103, 104, 105, 106])
 dev_2 = ds.commit("sec on dev_2")
 
@@ -175,7 +175,7 @@ In a Jupyter environment, you can view the changes visually.
 
 ### 5. Diff
 
-`ds.diff()` computes differences across versions for each tensor column and each sample (row). This API primarily supports merge computation, so its output is **not** a simple “absolute diff”; it returns diffs **per commit** relative to the most recent common ancestor (a version-tree style output, similar to `log()`).
+`ds.diff()` computes differences across versions for each column and each sample (row). This API primarily supports merge computation, so its output is **not** a simple “absolute diff”; it returns diffs **per commit** relative to the most recent common ancestor (a version-tree style output, similar to `log()`).
 
 Notes:
 
@@ -213,7 +213,7 @@ Key parameters:
 - **show_value (bool)**: if `True`, return actual values for append/update/pop.
 - **offset (int)**: number of items to skip (effective only when `show_value=True`).
 - **limit (int)**: maximum number of items to show (effective only when `show_value=True`, default 1000).
-- **asrow (bool)**: return values row-wise (list of dicts) when `show_value=True`. This is only applicable when tensor-count and row-count changes are exactly aligned between the two versions; otherwise it may raise an error. In general, prefer `asrow=False` for flexibility.
+- **asrow (bool)**: return values row-wise (list of dicts) when `show_value=True`. This is only applicable when column-count and row-count changes are exactly aligned between the two versions; otherwise it may raise an error. In general, prefer `asrow=False` for flexibility.
 
 Example (based on the dataset created in Section 5.2): show indices only.
 
@@ -235,10 +235,10 @@ No changes were made in this commit.
 commit 476be1766915dfe652f39e39f5370f9c04528df9
 Author: public
 Date: 2025-02-28 08:07:48
-Message: created categories tensor column and add values.
+Message: created categories column and add values.
 
 categories
-* Created tensor
+* Created column
 * Added 5 samples: [0-5]
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -269,10 +269,10 @@ Diff in 51f5bb41c4a1d74d881269366e3718285b8145db (target id 1):
 commit 51f5bb41c4a1d74d881269366e3718285b8145db
 Author: public
 Date: 2025-03-03 04:03:13
-Message: created categories tensor column and add values.
+Message: created categories column and add values.
 
 categories
-* Created tensor
+* Created column
 * Added 5 samples: [0-5],
 The appended data values are {'created': True, 'cleared': False, 'info_updated': False, 'data_added': [0, 5], 'data_updated': set(), 'data_deleted': SortedSet([]), 'data_deleted_ids': [], 'data_transformed_in_place': False, 'add_value': [array(['agent'], dtype='<U5'), array(['emotion'], dtype='<U7'), array(['generation'], dtype='<U10'), array(['writing'], dtype='<U7'), array(['emotion'], dtype='<U7')], 'updated_values': [], 'data_deleted_values': []}
 
@@ -301,7 +301,7 @@ Example: return values as a dict.
 >>> ds.diff(id_1=third_commit_id, id_2=first_commit_id, as_dict=True, show_value=True)
 {'dataset': ([{'commit_id': '51f5bb41c4a1d74d881269366e3718285b8145db',
     'author': 'public',
-    'message': 'created categories tensor column and add values.',
+    'message': 'created categories column and add values.',
     'date': '2025-03-03 04:03:13',
     'info_updated': False,
     'renamed': OrderedDict(),
@@ -362,12 +362,12 @@ Example: return values as a dict.
 
 Unlike Git, MULLER version control has **no local staging area**. All changes are immediately synced to the persistent storage location (local or remote). As a result, any dataset change updates the current branch HEAD node immediately. Uncommitted changes do not appear on other branches, but they remain accessible on the current branch until reverted.
 
-In the example below, we return to `main`, which has a `labels` tensor with 5 samples. We then append one sample and use `ds.has_head_changes` to confirm there are HEAD changes.
+In the example below, we return to `main`, which has a `labels` column with 5 samples. We then append one sample and use `ds.has_head_changes` to confirm there are HEAD changes.
 
 ```python
 >>> ds = muller.dataset(path="temp_dataset/", overwrite=True)
 >>> with ds:
-...     ds.create_tensor("labels", htype="generic")
+...     ds.create_column("labels", htype="generic")
 ...     ds.labels.extend([1, 2, 3, 4, 5])
 >>> ds.commit()
 >>> ds.checkout("dev", create=True)
@@ -378,20 +378,20 @@ In the example below, we return to `main`, which has a `labels` tensor with 5 sa
 True
 ```
 
-On the `dev` branch, the `labels` tensor still has 5 samples.
+On the `dev` branch, the `labels` column still has 5 samples.
 
 ```python
 >>> ds.checkout("dev")
->>> print("Dataset in {} branch has {} samples in the labels tensor".format(ds.branch, len(ds.labels)))
-Dataset in dev branch has 5 samples in the labels tensor
+>>> print("Dataset in {} branch has {} samples in the labels column".format(ds.branch, len(ds.labels)))
+Dataset in dev branch has 5 samples in the labels column
 ```
 
 Switch back to `main`, and the uncommitted change is still present (6 samples).
 
 ```python
 >>> ds.checkout("main")
->>> print("Dataset in {} branch has {} samples in the labels tensor".format(ds.branch, len(ds.labels)))
-Dataset in main branch has 6 samples in the labels tensor
+>>> print("Dataset in {} branch has {} samples in the labels column".format(ds.branch, len(ds.labels)))
+Dataset in main branch has 6 samples in the labels column
 >>> ds.has_head_changes
 True
 ```
@@ -402,8 +402,8 @@ Use `ds.reset()` to revert uncommitted changes on the current branch.
 >>> ds.reset()
 >>> ds.has_head_changes
 False
->>> print("Dataset in {} branch has {} samples in the labels tensor".format(ds.branch, len(ds.labels)))
-Dataset in main branch has 5 samples in the labels tensor
+>>> print("Dataset in {} branch has {} samples in the labels column".format(ds.branch, len(ds.labels)))
+Dataset in main branch has 5 samples in the labels column
 ```
 
 - For details, see [`dataset.reset()`](../api/dataset-version-control/#datasetreset).
@@ -429,7 +429,7 @@ MULLER currently follows the merge workflow below:
 
 - Find the most recent common ancestor (e.g., `M1`) between the current branch HEAD (e.g., `M3`) and the target branch head (e.g., `D4`).
 - Compute diffs `D4` vs `M1` and `M3` vs `M1`.
-- For tensors common to both branches, compare each sample by its UUID to detect conflicts. If conflicts exist, they are printed and also cached (in-memory) for subsequent merge steps.
+- For columns common to both branches, compare each sample by its UUID to detect conflicts. If conflicts exist, they are printed and also cached (in-memory) for subsequent merge steps.
 
 Conflict types recorded:
 
@@ -445,8 +445,8 @@ Conflict types recorded:
 
 Additional merge parameters:
 
-- **delete_removed_tensors (bool, default False)**: if `True`, tensors deleted in the current-branch diff are discarded.
-- **force (bool, default False)**: relaxes certain rename-related constraints; for example, it may register a renamed tensor as a new tensor if the counterpart tensor is missing on the other side, or merge tensors under certain rename collisions.
+- **delete_removed_tensors (bool, default False)**: legacy option name; if `True`, columns deleted in the current-branch diff are discarded.
+- **force (bool, default False)**: relaxes certain rename-related constraints; for example, it may register a renamed column as a new column if the counterpart column is missing on the other side, or merge columns under certain rename collisions.
 
 Important notes:
 
@@ -459,9 +459,9 @@ Example:
 ```python
 # Create a dataset and add data on main
 >>> ds = muller.dataset(path="temp_test", overwrite=True)
->>> ds.create_tensor(name="labels", htype="generic", dtype="int")
+>>> ds.create_column(name="labels", htype="generic", dtype="int")
 >>> ds.labels.extend([0, 1, 2, 3, 4])
->>> ds.create_tensor(name="categories", htype="text")
+>>> ds.create_column(name="categories", htype="text")
 >>> ds.categories.extend(["a", "b", "c", "d", "e"])
 
 # Create dev-1 and perform add/update/delete operations
@@ -511,7 +511,7 @@ Example:
  [70]]
 
 # Detect conflicts between main and dev-2
->>> conflict_tensors, conflict_records = ds.detect_merge_conflict("dev-2", show_value=True)
+>>> conflict_columns, conflict_records = ds.detect_merge_conflict("dev-2", show_value=True)
 >>> pprint(conflict_records)
 {'categories': {'app_ori_idx': [4, 5, 6],
                 'app_ori_values': [array(['ff'], dtype='<U2'),
@@ -576,23 +576,23 @@ ds.rename()
 
 ```python
 ds.reset()
-ds.create_tensor()
-ds.create_tensor_like()
+ds.create_column()
+ds.create_column_like()
 ds.commit()
 ds.extend([dataset_object])
-ds.<tensor>.extend()
+ds.<column>.extend()
 ds.delete_branch()
 ds.rechunk()
 ds.append([dataset_object])
-ds.<tensor>.append
+ds.<column>.append
 ds.update()  # there are two update methods
 ds.merge()
-ds.delete_tensor()
+ds.delete_column()
 ds.pop()
 ds.rename()
 muller.api_dataset.create_dataset_from_dataframes()
 muller.api_dataset.create_dataset_from_file()
-ds.<tensor>.clear()
+ds.<column>.clear()
 ds.create_index()
 ```
 

--- a/docs/getting_started/5_advanced_operations.md
+++ b/docs/getting_started/5_advanced_operations.md
@@ -14,8 +14,8 @@ Example:
 def create_cifar10_dataset_parallel(num_workers=4, scheduler="threaded"):
     ds_multi = muller.dataset(path="./temp_test", overwrite=True)
     with ds_multi:
-        ds_multi.create_tensor("test1", htype="text")
-        ds_multi.create_tensor("test2", htype="text")
+        ds_multi.create_column("test1", htype="text")
+        ds_multi.create_column("test2", htype="text")
 
     # Add data row-by-row to preserve row-level atomicity
     iter_dict = []
@@ -59,7 +59,7 @@ With large datasets, not every sample path is guaranteed to be valid (e.g., inva
 
 ```python
 for i in range(10):
-    ds.my_tensor.append(i)
+    ds.my_column.append(i)
 ```
 
 1. Using a `with` block typically improves performance. Updates are batched and flushed when the `with` block completes (or when the local cache is full), reducing fragmented writes:
@@ -67,14 +67,14 @@ for i in range(10):
 ```python
 with ds:
     for i in range(10):
-        ds.my_tensor.append(i)  # or other write operations: create, update, etc.
+        ds.my_column.append(i)  # or other write operations: create, update, etc.
 ```
 
 ### 3. Why a Dataset Become Corrupted, and How to Recover?
 
-If your program is interrupted unexpectedly (e.g., a crash during append/pop), the dataset may become inconsistent: some tensors may have been updated while others were not. In such cases, you can use `ds.reset()` to roll back illegal, uncommitted operations and return to the most recent valid commit.
+If your program is interrupted unexpectedly (e.g., a crash during append/pop), the dataset may become inconsistent: some columns may have been updated while others were not. In such cases, you can use `ds.reset()` to roll back illegal, uncommitted operations and return to the most recent valid commit.
 
-1. **Scenario A:** The dataset (or some tensors) cannot be read (e.g., you see an error like below).
+1. **Scenario A:** The dataset (or some columns) cannot be read (e.g., you see an error like below).
 
 ```text
 DatasetCorruptError: Exception occured (see Traceback). The dataset maybe corrupted. Try using `reset=True` to reset HEAD changes and load the previous commit. This will delete all uncommitted changes on the branch you are trying to load.
@@ -86,7 +86,7 @@ Recovery: reload with `reset=True`.
 ds = muller.load(<dataset_path>, reset=True)
 ```
 
-1. **Scenario B:** The dataset is corrupted (e.g., tensor lengths are inconsistent).
+1. **Scenario B:** The dataset is corrupted (e.g., column lengths are inconsistent).
 
 Recovery: load without integrity checking, then reset.
 
@@ -162,9 +162,9 @@ Key differences include:
 
 ```python
 # Fetch adjacent data in the chunk -> increases speed when loading sequentially,
-# or when a tensor's data fits in the cache.
+# or when a column's data fits in the cache.
 numeric_label = ds.labels[i].numpy(fetch_chunks=True)
 ```
 
-> Note: If `True`, full chunks will be retrieved from the storage; otherwise only required bytes will be retrieved. This will always be `True` even if specified as `False` in the following cases: (1) the tensor is ChunkCompressed; (2) the chunk being accessed has more than 128 samples.
+> Note: If `True`, full chunks will be retrieved from the storage; otherwise only required bytes will be retrieved. This will always be `True` even if specified as `False` in the following cases: (1) the column is chunk-compressed; (2) the chunk being accessed has more than 128 samples.
 

--- a/muller/__init__.py
+++ b/muller/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "load",
     "dataset",
     "Dataset",
+    "Column",
     "__version__",
     "delete",
     "compute",
@@ -23,6 +24,7 @@ __all__ = [
     "like",
     "tiled",
     "Sample",
+    "column",
     "from_file",
     "from_dataframes",
     "from_csv",
@@ -60,6 +62,8 @@ if sys.version_info < (3, 11):
 
 # The api of muller tensor
 tensor = Tensor
+Column = Tensor
+column = Tensor
 
 import muller.api
 

--- a/muller/api/dataset/copy.py
+++ b/muller/api/dataset/copy.py
@@ -24,15 +24,17 @@ def like(
         tensors: Optional[List[str]] = None,
         overwrite: bool = False,
         verbose: bool = True,
+        columns: Optional[List[str]] = None,
 ) -> Dataset:
     """Copies the `source` dataset's structure to a new location.
-    No samples are copied, only the meta/info for the dataset and its tensors.
+    No samples are copied, only the meta/info for the dataset and its columns.
 
     Args:
         dest(Union[str, Dataset]): Empty Dataset or Path where the new dataset will be created.
         src (Union[str, Dataset]): Path or dataset object that will be used as the template for the new dataset.
-        tensors (List[str], optional): Names of tensors (and groups) to be replicated.
-            If not specified all tensors in source dataset are considered.
+        columns (List[str], optional): Names of columns (and groups) to be replicated.
+            If not specified all columns in source dataset are considered.
+        tensors (List[str], optional): Legacy alias for ``columns``.
         overwrite (bool): If True and a dataset exists at `destination`, it will be overwritten. Defaults to False.
         verbose (bool): If True, logs will be printed. Defaults to ``True``.
 
@@ -50,10 +52,13 @@ def like(
         source_ds = src
         src_path = src.path
 
-    if tensors:
-        tensors = source_ds.resolve_tensor_list(tensors)  # type: ignore
+    if columns is None:
+        columns = tensors
+
+    if columns:
+        columns = source_ds.resolve_column_list(columns)  # type: ignore
     else:
-        tensors = list(source_ds.tensors.keys())  # type: ignore
+        columns = list(source_ds.columns.keys())  # type: ignore
 
     if isinstance(dest, Dataset):
         destination_ds = dest
@@ -65,11 +70,11 @@ def like(
         else:
             destination_ds = empty(dest_path, overwrite=overwrite)  # type: ignore
 
-    for tensor_name in tensors:  # type: ignore
-        source_tensor = source_ds[tensor_name]
-        if overwrite and tensor_name in destination_ds:
-            destination_ds.delete_tensor(tensor_name)
-        destination_ds.create_tensor_like(tensor_name, source_tensor)  # type: ignore
+    for column_name in columns:  # type: ignore
+        source_column = source_ds[column_name]
+        if overwrite and column_name in destination_ds:
+            destination_ds.delete_column(column_name)
+        destination_ds.create_column_like(column_name, source_column)  # type: ignore
 
     destination_ds.info.update(source_ds.info.__getstate__())  # type: ignore
 

--- a/muller/core/dataset/dataset.py
+++ b/muller/core/dataset/dataset.py
@@ -594,6 +594,11 @@ class Dataset(
         return self.get_tensors(include_hidden=False, include_disabled=False)
 
     @property
+    def columns(self) -> Dict[str, Tensor]:
+        """All user-visible columns belonging to this dataset."""
+        return self.tensors
+
+    @property
     def branches(self):
         """Lists all the branches of the dataset. """
         return self.version_state.get("branch_info", "Not Supported")
@@ -627,6 +632,11 @@ class Dataset(
         return indexed
 
     @property
+    def indexed_columns(self) -> List[str]:
+        """Returns the columns with inverted indexes built."""
+        return self.indexed_tensors
+
+    @property
     def indexed_tensors_vec(self) -> Set[str]:
         """Returns the tensor column with inverted index (vectorized version) built as a list."""
         indexed = set()
@@ -640,6 +650,11 @@ class Dataset(
         except KeyError:
             pass
         return indexed
+
+    @property
+    def indexed_columns_vec(self) -> Set[str]:
+        """Returns the columns with vectorized inverted indexes built."""
+        return self.indexed_tensors_vec
 
     @property
     def pending_commit_id(self) -> str:
@@ -820,6 +835,10 @@ class Dataset(
         from muller.core.dataset.tensor_access import resolve_tensor_list
         return resolve_tensor_list(self, keys)
 
+    def resolve_column_list(self, keys: List[str]) -> List[str]:
+        """Resolve a column list."""
+        return self.resolve_tensor_list(keys)
+
     @user_permission_check
     def create_tensor(
             self,
@@ -836,6 +855,20 @@ class Dataset(
                                                                   chunk_compression, hidden,
                                                                   **kwargs)
 
+    @user_permission_check
+    def create_column(
+            self,
+            name: str,
+            htype: str = UNSPECIFIED,
+            dtype: Union[str, np.dtype] = UNSPECIFIED,
+            sample_compression: Union[str, None] = UNSPECIFIED,
+            chunk_compression: str = UNSPECIFIED,
+            hidden: bool = False,
+            **kwargs,
+    ):
+        """Create a column. Alias for ``create_tensor``."""
+        return self.create_tensor(name, htype, dtype, sample_compression, chunk_compression, hidden, **kwargs)
+
     @invalid_view_op
     @user_permission_check
     def create_tensor_like(
@@ -849,9 +882,26 @@ class Dataset(
 
     @invalid_view_op
     @user_permission_check
+    def create_column_like(
+            self, name: str, source: "Tensor",
+    ) -> "Tensor":
+        """
+        Copies the ``source`` column's meta information and creates a new column with it.
+        No samples are copied, only the meta/info for the column is.
+        """
+        return self.create_tensor_like(name, source)
+
+    @invalid_view_op
+    @user_permission_check
     def delete_tensor(self, name: str, large_ok: bool = False):
         """Delete a tensor."""
         return muller.core.dataset.delete_tensor(self, name, large_ok)
+
+    @invalid_view_op
+    @user_permission_check
+    def delete_column(self, name: str, large_ok: bool = False):
+        """Delete a column. Alias for ``delete_tensor``."""
+        return self.delete_tensor(name, large_ok)
 
     @user_permission_check
     def extend(
@@ -904,11 +954,21 @@ class Dataset(
         """Function to handle rename tensor"""
         muller.core.dataset.handle_rename_tensor(self, name, new_name)
 
+    def handle_rename_column(self, name, new_name):
+        """Function to handle rename column."""
+        self.handle_rename_tensor(name, new_name)
+
     @invalid_view_op
     @user_permission_check
     def rename_tensor(self, name: str, new_name: str):
         """Renames tensor with name ``name`` to ``new_name``"""
         return muller.core.dataset.rename_tensor(self, name, new_name)
+
+    @invalid_view_op
+    @user_permission_check
+    def rename_column(self, name: str, new_name: str):
+        """Renames column with name ``name`` to ``new_name``."""
+        return self.rename_tensor(name, new_name)
 
     @user_permission_check
     def add_data_from_file(self, ori_path="", schema=None, workers=0, scheduler="processed", disable_rechunk=True,
@@ -971,21 +1031,28 @@ class Dataset(
     @user_permission_check
     def rechunk(
             self,
-            tensors: Optional[Union[str, List[str]]] = None,
+            columns: Optional[Union[str, List[str]]] = None,
             num_workers: int = 0,
             scheduler: str = "threaded",
             progressbar: bool = True,
+            tensors: Optional[Union[str, List[str]]] = None,
     ):
         """Rechunk the dataset."""
+        if columns is None:
+            columns = tensors
+        tensors = columns
         return muller.core.dataset.dataset_rechunk(self, tensors, num_workers, scheduler, progressbar)
 
     def rechunk_if_necessary(
             self,
+            column_spec: Optional[Union[List[str], Dict[str, Optional[int]]]] = None,
+            num_workers: int = 1,
             tensor_spec: Optional[Union[List[str], Dict[str, Optional[int]]]] = None,
-            num_workers: int = 1
     ) -> None:
-        """ Rechunk the data chunks on several tensors. """
-        return muller.core.dataset.dataset_rechunk_if_necessary(self, tensor_spec, num_workers)
+        """Rechunk the data chunks on several columns."""
+        if column_spec is None:
+            column_spec = tensor_spec
+        return muller.core.dataset.dataset_rechunk_if_necessary(self, column_spec, num_workers)
 
     def check_uuid(self):
         """Check uuids"""
@@ -1275,10 +1342,12 @@ class Dataset(
         from muller.core.query.inverted_index_muller import InvertedIndex
         return InvertedIndex(self.storage, tensor, branch, use_uuid, optimize)
 
-    def query(self, tensor_name, query):
-        """Query the target tensor column based on inverted index."""
+    def query(self, column_name=None, query=None, tensor_name=None):
+        """Query the target column based on inverted index."""
+        if column_name is None:
+            column_name = tensor_name
         from muller.core.query.filter import query_with_inverted_index
-        return query_with_inverted_index(self, tensor_name, query)
+        return query_with_inverted_index(self, column_name, query)
 
     def filter(
             self,
@@ -1295,18 +1364,30 @@ class Dataset(
 
     def aggregate(
             self,
-            group_by_tensors: List[str],
-            selected_tensors: List[str],
-            order_by_tensors: Optional[list] = None,
-            aggregate_tensors: Optional[list] = None,
+            group_by_columns: Optional[List[str]] = None,
+            selected_columns: Optional[List[str]] = None,
+            order_by_columns: Optional[list] = None,
+            aggregate_columns: Optional[list] = None,
             function: Optional[Callable] = None,
             order_direction: str = 'DESC',
             num_workers: int = 0,
             scheduler: str = "processed",
             progressbar: bool = True,
             method: str = "count",
+            group_by_tensors: Optional[List[str]] = None,
+            selected_tensors: Optional[List[str]] = None,
+            order_by_tensors: Optional[list] = None,
+            aggregate_tensors: Optional[list] = None,
     ):
         """Conduct aggregation query on the dataset."""
+        if group_by_columns is None:
+            group_by_columns = group_by_tensors
+        if selected_columns is None:
+            selected_columns = selected_tensors
+        if order_by_columns is None:
+            order_by_columns = order_by_tensors
+        if aggregate_columns is None:
+            aggregate_columns = aggregate_tensors
         from muller.core.query import aggregate_dataset
         return aggregate_dataset(
             self,
@@ -1314,32 +1395,44 @@ class Dataset(
             num_workers=num_workers,
             scheduler=scheduler,
             progressbar=progressbar,
-            group_by_tensors=group_by_tensors,
-            selected_tensors=selected_tensors,
-            order_by_tensors=order_by_tensors,
-            aggregate_tensors=aggregate_tensors,
+            group_by_tensors=group_by_columns,
+            selected_tensors=selected_columns,
+            order_by_tensors=order_by_columns,
+            aggregate_tensors=aggregate_columns,
             order_direction=order_direction,
             method=method
         )
 
     def aggregate_vectorized(
             self,
-            group_by_tensors: List[str],
-            selected_tensors: List[str],
+            group_by_columns: Optional[List[str]] = None,
+            selected_columns: Optional[List[str]] = None,
+            order_by_columns: Optional[list] = None,
+            aggregate_columns: Optional[list] = None,
+            order_direction: Optional[str] = 'DESC',
+            method: str = 'count',
+            group_by_tensors: Optional[List[str]] = None,
+            selected_tensors: Optional[List[str]] = None,
             order_by_tensors: Optional[list] = None,
             aggregate_tensors: Optional[list] = None,
-            order_direction: Optional[str] = 'DESC',
-            method: str = 'count'
     ):
         """ A vectorized aggregate function accelerated by the parallel computing supported by numpy. """
 
+        if group_by_columns is None:
+            group_by_columns = group_by_tensors
+        if selected_columns is None:
+            selected_columns = selected_tensors
+        if order_by_columns is None:
+            order_by_columns = order_by_tensors
+        if aggregate_columns is None:
+            aggregate_columns = aggregate_tensors
         from muller.core.query import aggregate_vectorized_dataset
         return aggregate_vectorized_dataset(
             dataset=self,
-            group_by_tensors=group_by_tensors,
-            selected_tensors=selected_tensors,
-            order_by_tensors=order_by_tensors,
-            aggregate_tensors=aggregate_tensors,
+            group_by_tensors=group_by_columns,
+            selected_tensors=selected_columns,
+            order_by_tensors=order_by_columns,
+            aggregate_tensors=aggregate_columns,
             order_direction=order_direction,
             method=method
         )
@@ -1381,55 +1474,74 @@ class Dataset(
 
     @invalid_view_op
     @user_permission_check
-    def create_vector_index(self, tensor_name: str, index_name: str, index_type: str = 'FLAT', metric: str = 'l2',
-                            **kwargs: Union[int, float, str]):
-        """Create index for tensor in vector type. """
+    def create_vector_index(self, column_name: Optional[str] = None, index_name: Optional[str] = None,
+                            index_type: str = 'FLAT', metric: str = 'l2',
+                            tensor_name: Optional[str] = None, **kwargs: Union[int, float, str]):
+        """Create an index for a vector column."""
+        if column_name is None:
+            column_name = tensor_name
         from muller.core.query import create_vector_index
-        create_vector_index(self, tensor_name, index_name, index_type, metric, **kwargs)
+        create_vector_index(self, column_name, index_name, index_type, metric, **kwargs)
 
-    def update_vector_index(self, tensor_name: str, index_name: str) -> None:
-        """Update vector index after add some samples into dataset and commit. """
+    def update_vector_index(self, column_name: Optional[str] = None, index_name: Optional[str] = None,
+                            tensor_name: Optional[str] = None) -> None:
+        """Update vector index after adding samples into dataset and committing."""
+        if column_name is None:
+            column_name = tensor_name
         from muller.core.query import update_vector_index
-        update_vector_index(self, tensor_name, index_name)
+        update_vector_index(self, column_name, index_name)
 
-    def vector_search(self, query_vector: Union[NDArray, Tensor], tensor_name: str, index_name: str, **kwargs):
-        """KNN Search on vector index. """
+    def vector_search(self, query_vector: Union[NDArray, Tensor], column_name: Optional[str] = None,
+                      index_name: Optional[str] = None, tensor_name: Optional[str] = None, **kwargs):
+        """KNN search on vector index."""
+        if column_name is None:
+            column_name = tensor_name
         from muller.core.query import vector_search
-        return vector_search(self, query_vector, tensor_name, index_name, **kwargs)
+        return vector_search(self, query_vector, column_name, index_name, **kwargs)
 
-    def load_vector_index(self, tensor_name: str, index_name: str, **kwargs):
-        """Load vector index into memory when index is unloaded. """
+    def load_vector_index(self, column_name: Optional[str] = None, index_name: Optional[str] = None,
+                          tensor_name: Optional[str] = None, **kwargs):
+        """Load vector index into memory when index is unloaded."""
+        if column_name is None:
+            column_name = tensor_name
         from muller.core.query import load_vector_index
-        load_vector_index(self, tensor_name, index_name, **kwargs)
+        load_vector_index(self, column_name, index_name, **kwargs)
 
-    def unload_vector_index(self, tensor_name: str, index_name: str):
-        """ Unload vector index from memory when index is loaded. """
+    def unload_vector_index(self, column_name: Optional[str] = None, index_name: Optional[str] = None,
+                            tensor_name: Optional[str] = None):
+        """Unload vector index from memory when index is loaded."""
+        if column_name is None:
+            column_name = tensor_name
         from muller.core.query import unload_vector_index
-        unload_vector_index(self, tensor_name, index_name)
+        unload_vector_index(self, column_name, index_name)
 
-    def drop_vector_index(self, tensor_name: str, index_name: str):
-        """ Drop vector index permanently. """
+    def drop_vector_index(self, column_name: Optional[str] = None, index_name: Optional[str] = None,
+                          tensor_name: Optional[str] = None):
+        """Drop vector index permanently."""
+        if column_name is None:
+            column_name = tensor_name
         from muller.core.query import drop_vector_index
-        drop_vector_index(self, tensor_name, index_name)
+        drop_vector_index(self, column_name, index_name)
 
     def summary(self, force: bool = False):
         """Print out a summarization of the schema and statistic information of the dataset."""
         from muller.core.dataset.statistics.summary import summary_dataset
         summary_dataset(self, force)
 
-    def to_dataframe(self, tensor_list: Optional[List[str]] = None,
+    def to_dataframe(self, columns: Optional[List[str]] = None,
                      index_list: Optional[List] = None,
-                     force: bool = False):
+                     force: bool = False,
+                     tensor_list: Optional[List[str]] = None):
         """ Returns a pandas dataframe of the dataset.
         Example:
 
             >>> ds.to_dataframe()
             >>> ds.to_dataframe(index_list=[-1, -2])
-            >>> ds.to_dataframe(tensor_list=["categories"], index_list=[1, 2, 4])
+            >>> ds.to_dataframe(columns=["categories"], index_list=[1, 2, 4])
 
         Args:
-            tensor_list (List of str, Optional) - The tensor columns selected to be exported as pandas dataframe.
-                        If not provided, we will export all the tensor columns.
+            columns (List of str, Optional) - The columns selected to be exported as pandas dataframe.
+                        If not provided, we will export all columns.
             index_list (List of int, Optional) - The indices of the rows selected to be exported as pandas dataframe.
                         If not provided, we will export all the row.
             force (bool, Optional) - Dataset with more than TO_DATAFRAME_SAFE_LIMIT samples might take a long time to
@@ -1437,11 +1549,13 @@ class Dataset(
                         An error will be raised otherwise.
 
         Raises:
-            InvalidTensorList: If ``tensor_list`` contains tensors that are not in the current columns.
+            InvalidTensorList: If ``columns`` contains names that are not in the current columns.
             ToDataFrameLimit: If the length of ``index_list`` exceeds the TO_DATAFRAME_SAFE_LIMIT.
         """
+        if columns is None:
+            columns = tensor_list
         from muller.core.dataset.export_data.to_dataframe import to_dataframe
-        return to_dataframe(self, tensor_list, index_list, force)
+        return to_dataframe(self, columns, index_list, force)
 
     def to_arrow(self):
         """Returns an arrow object of the dataset."""
@@ -1465,8 +1579,9 @@ class Dataset(
     def to_json(
             self,
             path,
-            tensors: Optional[List[str]] = None,
+            columns: Optional[List[str]] = None,
             num_workers: Optional[int] = 1,
+            tensors: Optional[List[str]] = None,
     ):
         """Write MULLER data by row to a jsonl or json file.
 
@@ -1475,11 +1590,13 @@ class Dataset(
 
         Args:
             path (str): The jsonl or json file name to save MULLER data.
-            tensors (List of str, Optional): The tensor columns selected to be exported to the jsonl or json file.
+            columns (List of str, Optional): The columns selected to be exported to the jsonl or json file.
             num_workers (int, Optional): The number of workers that can be used to dump to the path.
         """
+        if columns is None:
+            columns = tensors
         from muller.core.dataset.export_data.to_json import to_json
-        to_json(self, path, tensors, num_workers)
+        to_json(self, path, columns, num_workers)
 
     def to_mindrecord(
             self,
@@ -1515,6 +1632,10 @@ class Dataset(
         from muller.core.dataset.tensor_access import get_tensors
         return get_tensors(self, include_hidden, include_disabled)
 
+    def get_columns(self, include_hidden: bool = True, include_disabled=True) -> Dict[str, Tensor]:
+        """All columns belonging to this group, including those within sub groups."""
+        return self.get_tensors(include_hidden, include_disabled)
+
     def populate_meta(self, address: Optional[str] = None, verbose=True):
         """Populates the meta information for the dataset."""
         from muller.core.dataset.metadata import populate_meta
@@ -1524,6 +1645,10 @@ class Dataset(
         """Names of all tensors belonging to this group, including those within sub groups"""
         from muller.core.dataset.tensor_access import all_tensors_filtered
         return all_tensors_filtered(self, include_hidden, include_disabled)
+
+    def all_columns_filtered(self, include_hidden: bool = True, include_disabled=True) -> List[str]:
+        """Names of all columns belonging to this group, including those within sub groups."""
+        return self.all_tensors_filtered(include_hidden, include_disabled)
 
     def get_sample_indices(self, maxlen: int):
         """Get sample indices"""
@@ -1554,6 +1679,10 @@ class Dataset(
         """Displays the differences between commits (in the same branch) for certain tensor."""
         # Delegated to VersionControlMixin
         return super().tensor_diff(id_1, id_2, tensors)
+
+    def column_diff(self, id_1, id_2, columns: List[str] = None):
+        """Displays the differences between commits for selected columns."""
+        return self.tensor_diff(id_1, id_2, columns)
 
     def sub_ds(
             self,

--- a/muller/core/dataset/statistics/summary.py
+++ b/muller/core/dataset/statistics/summary.py
@@ -50,7 +50,7 @@ def summary_dataset(dataset, force=False):
     ):
         raise SummaryLimit(dataset.max_len, VIEW_SUMMARY_SAFE_LIMIT)
 
-    head = ["tensor", "htype", "shape", "dtype", "compression"]
+    head = ["column", "htype", "shape", "dtype", "compression"]
     divider = ["-------"] * 5
     tensor_dict = dataset.tensors
     max_column_length = [7, 7, 7, 7, 7]

--- a/muller/util/muller_keywords.py
+++ b/muller/util/muller_keywords.py
@@ -10,6 +10,7 @@ import keyword
 
 muller_kwlist = [
     'tensors',  # The attributes of TransformDataset
+    'columns',
     'data',
     'embedding',
     'all_chunk_engines',
@@ -53,7 +54,16 @@ muller_kwlist = [
     'initial_autoflush',
     '_indexing_history',
     'read_only',
-    'is_first_load'
+    'is_first_load',
+    'create_column',
+    'create_column_like',
+    'delete_column',
+    'rename_column',
+    'indexed_columns',
+    'indexed_columns_vec',
+    'get_columns',
+    'all_columns_filtered',
+    'column_diff',
     ]
 
 

--- a/streamlit_ui/README.md
+++ b/streamlit_ui/README.md
@@ -79,7 +79,7 @@ The application will open in your default browser at `http://localhost:8501`.
 - **Batch Upload**: Upload CSV file with matching column names
 
 **View & Edit:**
-- View dataset summary (total samples, tensors, current branch)
+- View dataset summary (total samples, columns, current branch)
 - Browse data in table format
 - Delete samples by index
 
@@ -95,7 +95,7 @@ Supported operators:
 - Text: `CONTAINS`, `LIKE`
 
 **Vector Search:**
-- Requires embeddings tensor with vector index
+- Requires an embeddings column with a vector index
 - Feature available when dataset includes vector data
 
 ### 3. Version Control

--- a/streamlit_ui/demo_streamlit.py
+++ b/streamlit_ui/demo_streamlit.py
@@ -29,7 +29,7 @@ if _project_root not in sys.path:
     sys.path.insert(0, _project_root)
 
 from utils import (
-    create_dataset, create_tensors, add_samples, update_sample, delete_sample,
+    create_dataset, create_columns, add_samples, update_sample, delete_sample,
     run_query, dataset_to_dataframe, dataframe_for_streamlit_display,
     list_image_tensor_names, decode_muller_image_sample, pil_resize_to_height,
     pil_square_thumbnail, pil_fit_inside,
@@ -253,10 +253,10 @@ if page == "📊 Dataset Management":
                 st.session_state.schema_next_id = len(_DEFAULT_ROWS)
 
             # --- Bulk-load schema from JSON ---
-            # Typing a multi-tensor schema cell-by-cell is tedious and error
+            # Typing a multi-column schema cell-by-cell is tedious and error
             # prone, and skipping this step is the #1 reason the demo looks
             # "not like a COCO dataset" afterwards (you silently end up with
-            # the 3-tensor placeholder schema, and a subsequent Batch Upload
+            # the 3-column placeholder schema, and a subsequent Batch Upload
             # of a 9-column CSV drops 8 of the 9 columns on the floor). So:
             #   - this expander is *open by default* (file uploader visible)
             #   - below, ``Create Dataset`` blocks on the default placeholder
@@ -264,12 +264,12 @@ if page == "📊 Dataset Management":
             with st.expander("📥 Load schema from JSON file", expanded=True):
                 _schema_help_md = (
                     "Accepted shapes:  \n"
-                    "• `{\"tensors\": [{\"name\": …, \"htype\": …, \"dtype\": …, "
+                    "• `{\"columns\": [{\"name\": …, \"htype\": …, \"dtype\": …, "
                     "\"sample_compression\": …}, …]}`  \n"
                     "• a plain list of the same objects  \n"
                     "• a `{name: {htype, dtype, sample_compression}}` dict  \n"
                     "See `sigmod_demo_revision/coco_schema.json` for a ready-to-use "
-                    "9-tensor COCO2017 example (8 core tensors + `description` text)."
+                    "9-column COCO2017 example (8 core columns + `description` text)."
                 )
                 schema_file = st.file_uploader(
                     "Schema JSON", type=["json"], key="schema_json_upload",
@@ -278,8 +278,8 @@ if page == "📊 Dataset Management":
 
                 def _normalize_schema_entries(data):
                     """Return (list-of-dicts, errors)."""
-                    if isinstance(data, dict) and "tensors" in data:
-                        raw = data.get("tensors") or []
+                    if isinstance(data, dict) and ("columns" in data or "tensors" in data):
+                        raw = data.get("columns") or data.get("tensors") or []
                     elif isinstance(data, list):
                         raw = data
                     elif isinstance(data, dict):
@@ -305,7 +305,7 @@ if page == "📊 Dataset Management":
                         # MULLER accepts (e.g. "Any", "List", "jpeg" alias)
                         # that may not be in the shortlist dropdown, so we
                         # pass them through and let MULLER validate at
-                        # tensor-creation time; the UI below dynamically
+                        # column-creation time; the UI below dynamically
                         # extends its dropdowns to show whatever we got.
                         if ht not in HTYPE_OPTIONS:
                             errs.append(
@@ -326,7 +326,7 @@ if page == "📊 Dataset Management":
                         if errs:
                             st.error("Schema JSON has problems:\n- " + "\n- ".join(errs))
                         elif not normalized:
-                            st.error("Schema JSON has no valid tensor entries.")
+                            st.error("Schema JSON has no valid column entries.")
                         else:
                             # Fingerprint the applied schema so streamlit's
                             # auto-reruns don't re-apply on every keystroke.
@@ -341,7 +341,7 @@ if page == "📊 Dataset Management":
                                 st.session_state.schema_next_id = next_id
                                 st.session_state["_schema_json_sig"] = sig
                                 st.success(
-                                    f"Loaded **{len(normalized)}** tensor rows "
+                                    f"Loaded **{len(normalized)}** column rows "
                                     f"from `{schema_file.name}`."
                                 )
                                 st.rerun()
@@ -352,7 +352,7 @@ if page == "📊 Dataset Management":
                                     "below to tweak, or upload a different file."
                                 )
 
-            st.markdown("**Define Columns (Tensors)**")
+            st.markdown("**Define Columns**")
 
             # Header row
             h_name, h_htype, h_dtype, h_comp, h_btns = st.columns([3, 2, 2, 2, 1])
@@ -458,7 +458,7 @@ if page == "📊 Dataset Management":
                                         cfg["sample_compression"] = comp
                                     schema[name] = cfg
 
-                                err = create_tensors(ds, schema)
+                                err = create_columns(ds, schema)
                                 if err:
                                     st.error(err)
                                 else:
@@ -511,7 +511,7 @@ elif page == "📝 View & Edit":
             st.warning("Please create or load a dataset first.")
         else:
             ds = st.session_state.dataset
-            tensor_names = list(ds.tensors.keys())
+            column_names = list(ds.columns.keys())
             n = len(ds)
 
             # Per-action "flash" slots — each Add / Import / Delete / Update
@@ -543,14 +543,14 @@ elif page == "📝 View & Edit":
             # 1) Current Schema (collapsed by default)
             with st.expander("Current Schema", expanded=False):
                 schema_rows = []
-                for tname, t in ds.tensors.items():
-                    schema_rows.append({"Column": tname, "htype": t.htype, "dtype": str(t.dtype)})
+                for column_name, column in ds.columns.items():
+                    schema_rows.append({"Column": column_name, "htype": column.htype, "dtype": str(column.dtype)})
                 st.dataframe(pd.DataFrame(schema_rows), width="stretch", hide_index=True)
 
             # 2) Dataset details
             col1, col2, col3 = st.columns(3)
             col1.metric("Samples", n)
-            col2.metric("Tensors", len(ds.tensors))
+            col2.metric("Columns", len(ds.columns))
             col3.metric("Branch", ds.branch)
 
             if n == 0:
@@ -1048,48 +1048,48 @@ elif page == "📝 View & Edit":
             # 3) Add Single Sample (collapsed by default)
             with st.expander("Add Single Sample", expanded=False):
                 sample_data = {}
-                for tname in tensor_names:
-                    t = ds.tensors[tname]
-                    htype = t.htype
-                    dtype_str = str(t.dtype)
+                for col_name in column_names:
+                    column = ds.columns[col_name]
+                    htype = column.htype
+                    dtype_str = str(column.dtype)
 
                     if htype == "text":
-                        sample_data[tname] = [st.text_input(f"{tname} (text)", key=f"add_{tname}")]
+                        sample_data[col_name] = [st.text_input(f"{col_name} (text)", key=f"add_{col_name}")]
                     elif htype in ("image", "video", "audio"):
                         file_types = {"image": ["jpg", "png", "jpeg", "bmp"],
                                       "video": ["mp4", "avi", "mov"],
                                       "audio": ["mp3", "wav", "flac"]}
                         uploaded_file = st.file_uploader(
-                            f"{tname} ({htype})", type=file_types.get(htype, []),
-                            key=f"add_{tname}")
+                            f"{col_name} ({htype})", type=file_types.get(htype, []),
+                            key=f"add_{col_name}")
                         if uploaded_file is not None:
-                            sample_data[tname] = [np.frombuffer(uploaded_file.read(), dtype=np.uint8)]
+                            sample_data[col_name] = [np.frombuffer(uploaded_file.read(), dtype=np.uint8)]
                         else:
-                            sample_data[tname] = None
+                            sample_data[col_name] = None
                     elif "int" in dtype_str:
-                        val = st.text_input(f"{tname} (integer)", value="0", key=f"add_{tname}")
+                        val = st.text_input(f"{col_name} (integer)", value="0", key=f"add_{col_name}")
                         try:
-                            sample_data[tname] = [int(val)]
+                            sample_data[col_name] = [int(val)]
                         except ValueError:
-                            sample_data[tname] = [0]
+                            sample_data[col_name] = [0]
                     elif "float" in dtype_str:
-                        val = st.text_input(f"{tname} (float)", value="0.0", key=f"add_{tname}")
+                        val = st.text_input(f"{col_name} (float)", value="0.0", key=f"add_{col_name}")
                         try:
-                            sample_data[tname] = [float(val)]
+                            sample_data[col_name] = [float(val)]
                         except ValueError:
-                            sample_data[tname] = [0.0]
+                            sample_data[col_name] = [0.0]
                     elif "bool" in dtype_str:
-                        val = st.checkbox(f"{tname} (bool)", key=f"add_{tname}")
-                        sample_data[tname] = [val]
+                        val = st.checkbox(f"{col_name} (bool)", key=f"add_{col_name}")
+                        sample_data[col_name] = [val]
                     else:
-                        val = st.text_input(f"{tname}", key=f"add_{tname}")
+                        val = st.text_input(f"{col_name}", key=f"add_{col_name}")
                         try:
-                            sample_data[tname] = [int(val)]
+                            sample_data[col_name] = [int(val)]
                         except ValueError:
                             try:
-                                sample_data[tname] = [float(val)]
+                                sample_data[col_name] = [float(val)]
                             except ValueError:
-                                sample_data[tname] = [val]
+                                sample_data[col_name] = [val]
 
                 add_commit_msg = st.text_input(
                     "Commit Message", value="Add sample via Streamlit UI",
@@ -1119,8 +1119,8 @@ elif page == "📝 View & Edit":
                 if uploaded is not None:
                     df_up = pd.read_csv(uploaded)
 
-                    matched = [col for col in df_up.columns if col in tensor_names]
-                    unmatched = [col for col in df_up.columns if col not in tensor_names]
+                    matched = [col for col in df_up.columns if col in column_names]
+                    unmatched = [col for col in df_up.columns if col not in column_names]
                     if matched:
                         st.info(f"Matched columns: {matched}")
                     if unmatched:
@@ -1156,9 +1156,9 @@ elif page == "📝 View & Edit":
                     #    variable-length area / category_id / id / iscrowd)
                     #  - "skip" (i.e. not in path_columns) for plain scalars
                     #
-                    # Why sniff the CSV content instead of the tensor metadata:
-                    # at Batch Upload time the target tensor was just created
-                    # and holds no samples, so tensor.shape is (0,) and we
+                    # Why sniff the CSV content instead of the column metadata:
+                    # at Batch Upload time the target column was just created
+                    # and holds no samples, so column.shape is (0,) and we
                     # cannot tell from the schema alone whether a `generic`
                     # column will hold one number or a length-N array. The
                     # CSV cell itself is the source of truth — a leading `[`
@@ -1179,8 +1179,8 @@ elif page == "📝 View & Edit":
                                 return True
                         return False
 
-                    def _infer_mode(col_name, tensor):
-                        h = (tensor.htype or "").lower()
+                    def _infer_mode(col_name, column):
+                        h = (column.htype or "").lower()
                         if h in ("image", "video", "audio"):
                             return "read"
                         # Some htypes are inherently non-scalar regardless of
@@ -1195,7 +1195,7 @@ elif page == "📝 View & Edit":
                             return "json"
                         return "skip"
 
-                    inferred = {col: _infer_mode(col, ds.tensors[col]) for col in matched}
+                    inferred = {col: _infer_mode(col, ds.columns[col]) for col in matched}
 
                     # Apply inferred import modes silently so the demo UI stays
                     # compact after a CSV is uploaded.
@@ -1209,7 +1209,7 @@ elif page == "📝 View & Edit":
                     if st.button("Import CSV Data"):
                         if not matched:
                             st.session_state["_flash_csv"] = (
-                                "error", f"CSV columns must match tensors: {tensor_names}"
+                                "error", f"CSV columns must match dataset columns: {column_names}"
                             )
                         else:
                             tmp_path = None
@@ -1266,7 +1266,7 @@ elif page == "📝 View & Edit":
                     st.info("No samples to update.")
                 else:
                     upd_idx = st.number_input("Sample Index to Update", min_value=0, max_value=max(n - 1, 0), value=0, key="upd_idx")
-                    upd_tensor = st.selectbox("Tensor", list(ds.tensors.keys()), key="upd_tensor")
+                    upd_column = st.selectbox("Column", list(ds.columns.keys()), key="upd_column")
                     upd_val = st.text_input("New Value", key="upd_val")
                     upd_commit_msg = st.text_input(
                         "Commit Message", value="Update sample via Streamlit UI",
@@ -1274,8 +1274,8 @@ elif page == "📝 View & Edit":
                     if st.button("Update", type="secondary"):
                         # Try JSON first so users can paste array literals like
                         # "[1]" or "[[1,2,3,4]]" (matches the CSV-import "json"
-                        # mode for non-scalar tensors); fall back to int / float
-                        # / raw string for scalar tensors.
+                        # mode for non-scalar columns); fall back to int / float
+                        # / raw string for scalar columns.
                         parsed = None
                         _stripped = (upd_val or "").strip()
                         if _stripped and _stripped[0] in "[{":
@@ -1292,14 +1292,14 @@ elif page == "📝 View & Edit":
                                     parsed = float(upd_val)
                                 except ValueError:
                                     parsed = upd_val
-                        err = update_sample(ds, upd_tensor, upd_idx, parsed)
+                        err = update_sample(ds, upd_column, upd_idx, parsed)
                         if err:
                             st.session_state["_flash_upd"] = ("error", err)
                         else:
                             commit_dataset(ds, message=upd_commit_msg)
                             st.session_state["_flash_upd"] = (
                                 "success",
-                                f"Updated `{upd_tensor}[{upd_idx}]` -> `{parsed}` (commit: `{upd_commit_msg}`).",
+                                f"Updated `{upd_column}[{upd_idx}]` -> `{parsed}` (commit: `{upd_commit_msg}`).",
                             )
                             st.rerun()
                 _render_flash("_flash_upd")
@@ -1315,7 +1315,7 @@ elif page == "🔍 Query & Search":
         st.warning("Please create or load a dataset first.")
     else:
         ds = st.session_state.dataset
-        tensor_names = list(ds.tensors.keys())
+        column_names = list(ds.columns.keys())
 
         # Result of the most recent query/view load lives across reruns so the
         # user can scroll, tweak display options, and then save it as a view
@@ -1464,7 +1464,7 @@ elif page == "🔍 Query & Search":
 
                 with c_field:
                     field = st.selectbox("Field" if pos == 0 else "Field",
-                                         tensor_names, key=f"field_{cid}",
+                                         column_names, key=f"field_{cid}",
                                          label_visibility="collapsed" if pos > 0 else "visible")
                 with c_op:
                     op = st.selectbox("Op" if pos == 0 else "Op",
@@ -1536,37 +1536,37 @@ elif page == "🔍 Query & Search":
         else:  # Vector search
             st.subheader("Vector Similarity Search")
 
-            vec_tensors = list_vector_tensor_names(ds)
+            vec_columns = list_vector_tensor_names(ds)
             idx_map = list_vector_indexes(ds)
 
-            if not vec_tensors and not idx_map:
+            if not vec_columns and not idx_map:
                 st.info(
-                    "No `embedding`/`vector` tensor declared on this dataset. "
+                    "No `embedding`/`vector` column declared on this dataset. "
                     "Add one with `htype='embedding'` (float32), populate it, "
                     "then build an index via `ds.create_vector_index(...)`."
                 )
             else:
-                # Allow choosing any tensor that *has* an index, even if its
+                # Allow choosing any column that *has* an index, even if its
                 # declared htype is not literally 'embedding' — so users with
-                # generic float tensors + an index are not blocked.
-                selectable = sorted(set(vec_tensors) | set(idx_map.keys()))
+                # generic float columns + an index are not blocked.
+                selectable = sorted(set(vec_columns) | set(idx_map.keys()))
                 col_t, col_i, col_k = st.columns([2, 2, 1])
                 with col_t:
-                    v_tensor = st.selectbox(
-                        "Embedding tensor", selectable, key="qs_vec_tensor"
+                    v_column = st.selectbox(
+                        "Embedding column", selectable, key="qs_vec_column"
                     )
-                indexes_for_tensor = idx_map.get(v_tensor, [])
+                indexes_for_column = idx_map.get(v_column, [])
                 with col_i:
-                    if indexes_for_tensor:
+                    if indexes_for_column:
                         v_index = st.selectbox(
-                            "Vector index", indexes_for_tensor, key="qs_vec_index"
+                            "Vector index", indexes_for_column, key="qs_vec_index"
                         )
                     else:
                         v_index = st.text_input(
                             "Vector index (will be created)",
                             value="demo_flat",
                             key="qs_vec_index_new",
-                            help="No existing index on this tensor; one will be "
+                            help="No existing index on this column; one will be "
                             "built on the current commit when you run the search.",
                         )
                 with col_k:
@@ -1575,7 +1575,7 @@ elif page == "🔍 Query & Search":
                         key="qs_vec_topk",
                     )
 
-                dim = tensor_embedding_dim(ds, v_tensor)
+                dim = tensor_embedding_dim(ds, v_column)
                 qv_help = (
                     f"Comma/space-separated floats. Expected dimension: {dim}"
                     if dim else "Comma/space-separated floats."
@@ -1589,13 +1589,13 @@ elif page == "🔍 Query & Search":
                 col_metric, col_type = st.columns(2)
                 with col_metric:
                     metric = st.selectbox("Metric", ["l2", "cosine", "ip"], key="qs_vec_metric",
-                                          disabled=bool(indexes_for_tensor),
+                                          disabled=bool(indexes_for_column),
                                           help="Ignored when reusing an existing index "
                                           "(that index was built with its own metric).")
                 with col_type:
                     index_type = st.selectbox("Index type", ["FLAT", "IVF", "IVFPQ"],
                                               key="qs_vec_idx_type",
-                                              disabled=bool(indexes_for_tensor),
+                                              disabled=bool(indexes_for_column),
                                               help="Used only when creating a new index.")
 
                 if st.button("Run Vector Search", type="primary", key="qs_run_vec"):
@@ -1603,12 +1603,12 @@ elif page == "🔍 Query & Search":
                     if perr:
                         st.error(perr)
                     else:
-                        if not indexes_for_tensor:
+                        if not indexes_for_column:
                             with st.spinner(
-                                f"Building vector index '{v_index}' on '{v_tensor}'…"
+                                f"Building vector index '{v_index}' on '{v_column}'…"
                             ):
                                 ierr = ensure_vector_index(
-                                    ds, v_tensor, v_index,
+                                    ds, v_column, v_index,
                                     index_type=index_type, metric=metric,
                                 )
                             if ierr:
@@ -1616,7 +1616,7 @@ elif page == "🔍 Query & Search":
                                 st.stop()
                         with st.spinner("Searching…"):
                             result_ds, positions, dists, verr = run_vector_search(
-                                ds, v_tensor, v_index, qvec, topk=int(topk),
+                                ds, v_column, v_index, qvec, topk=int(topk),
                             )
                         if verr:
                             st.error(verr)
@@ -1624,12 +1624,12 @@ elif page == "🔍 Query & Search":
                             n_hits = len(result_ds) if result_ds is not None else 0
                             st.session_state["qs_result_ds"] = result_ds
                             st.session_state["qs_result_desc"] = (
-                                f"Vector search on `{v_tensor}` (index `{v_index}`, "
+                                f"Vector search on `{v_column}` (index `{v_index}`, "
                                 f"top-{int(topk)}) → {n_hits} hits"
                             )
                             st.session_state["qs_result_meta"] = {
                                 "source": "vector",
-                                "tensor": v_tensor,
+                                "column": v_column,
                                 "index": v_index,
                                 "topk": int(topk),
                                 "positions": list(positions or []),
@@ -2031,10 +2031,10 @@ elif page == "🌿 Version Control":
                     st.session_state.pop("_merge_detect_state", None)
                     st.error(err)
                 else:
-                    # Check tensor-level conflicts (renames/deletes)
-                    has_tensor_conflicts = bool(result["columns"])
+                    # Check column-level conflicts (renames/deletes)
+                    has_column_conflicts = bool(result["columns"])
 
-                    # Check sample-level conflicts across ALL common tensors.
+                    # Check sample-level conflicts across ALL common columns.
                     # MULLER's `detect_merge_conflict` returns *differences vs. LCA*
                     # in `del_ori_idx / del_tar_idx / app_ori_idx / app_tar_idx`,
                     # NOT conflicts. A real conflict requires divergence on the
@@ -2048,7 +2048,7 @@ elif page == "🌿 Version Control":
                     #   - delete: only a conflict when both sides popped the SAME
                     #     LCA index (`pop_resolution` is needed). One-sided deletes
                     #     merge cleanly without a strategy.
-                    tensors_with_sample_conflicts = []
+                    columns_with_sample_conflicts = []
                     for col_name, cdata in result.get("records", {}).items():
                         has_append = bool(cdata.get("app_ori_idx") and cdata.get("app_tar_idx"))
                         has_update = False
@@ -2059,42 +2059,42 @@ elif page == "🌿 Version Control":
                         tar_del = set(cdata.get("del_tar_idx") or [])
                         has_delete = bool(ori_del & tar_del)
                         if has_append or has_update or has_delete:
-                            tensors_with_sample_conflicts.append(col_name)
-                    tensors_with_delete_diffs = [
+                            columns_with_sample_conflicts.append(col_name)
+                    columns_with_delete_diffs = [
                         col_name
                         for col_name, cdata in result.get("records", {}).items()
                         if (cdata.get("del_ori_idx") or cdata.get("del_tar_idx"))
                     ]
                     _merge_detect_state = {
                         "ctx": _merge_detect_ctx,
-                        "has_conflicts": bool(has_tensor_conflicts or tensors_with_sample_conflicts),
+                        "has_conflicts": bool(has_column_conflicts or columns_with_sample_conflicts),
                         "result": result,
-                        "tensors_with_sample_conflicts": tensors_with_sample_conflicts,
-                        "tensors_with_delete_diffs": tensors_with_delete_diffs,
+                        "columns_with_sample_conflicts": columns_with_sample_conflicts,
+                        "columns_with_delete_diffs": columns_with_delete_diffs,
                     }
                     st.session_state["_merge_detect_state"] = _merge_detect_state
 
             if _merge_detect_state:
                 result = _merge_detect_state["result"]
-                tensors_with_sample_conflicts = _merge_detect_state["tensors_with_sample_conflicts"]
-                tensors_with_delete_diffs = _merge_detect_state.get("tensors_with_delete_diffs", [])
-                has_tensor_conflicts = bool(result["columns"])
+                columns_with_sample_conflicts = _merge_detect_state["columns_with_sample_conflicts"]
+                columns_with_delete_diffs = _merge_detect_state.get("columns_with_delete_diffs", [])
+                has_column_conflicts = bool(result["columns"])
 
                 if _merge_detect_state["has_conflicts"]:
                     conflict_summary = []
-                    if has_tensor_conflicts:
-                        conflict_summary.append(f"Tensor conflicts: {', '.join(result['columns'])}")
-                    if tensors_with_sample_conflicts:
-                        conflict_summary.append(f"Sample conflicts in: {', '.join(tensors_with_sample_conflicts)}")
+                    if has_column_conflicts:
+                        conflict_summary.append(f"Column conflicts: {', '.join(result['columns'])}")
+                    if columns_with_sample_conflicts:
+                        conflict_summary.append(f"Sample conflicts in: {', '.join(columns_with_sample_conflicts)}")
                     st.warning(" | ".join(conflict_summary))
 
-                    # Show details for all tensors that have any conflict
-                    all_conflict_tensors = set(tensors_with_sample_conflicts)
-                    if has_tensor_conflicts:
-                        all_conflict_tensors.update(result["columns"])
+                    # Show details for all columns that have any conflict
+                    all_conflict_columns = set(columns_with_sample_conflicts)
+                    if has_column_conflicts:
+                        all_conflict_columns.update(result["columns"])
 
                     summary_rows = []
-                    for col_name in sorted(all_conflict_tensors):
+                    for col_name in sorted(all_conflict_columns):
                         cdata = result["records"].get(col_name, {})
                         update_ori = (cdata.get("update_values") or {}).get("update_ori", [])
                         update_tar = (cdata.get("update_values") or {}).get("update_tar", [])
@@ -2106,8 +2106,8 @@ elif page == "🌿 Version Control":
                         del_ori = set(cdata.get("del_ori_idx") or [])
                         del_tar = set(cdata.get("del_tar_idx") or [])
                         summary_rows.append({
-                            "Tensor": col_name,
-                            "Tensor conflict": "yes" if col_name in result.get("columns", []) else "",
+                            "Column": col_name,
+                            "Column conflict": "yes" if col_name in result.get("columns", []) else "",
                             "Append rows (ours/theirs)": (
                                 f"{len(cdata.get('app_ori_idx') or [])} / "
                                 f"{len(cdata.get('app_tar_idx') or [])}"
@@ -2121,7 +2121,7 @@ elif page == "🌿 Version Control":
                         st.dataframe(pd.DataFrame(summary_rows), width="stretch", hide_index=True)
 
                     with st.expander("Show conflict details (optional)", expanded=False):
-                        for col_name in sorted(all_conflict_tensors):
+                        for col_name in sorted(all_conflict_columns):
                             st.markdown(f"#### `{col_name}`")
                             cdata = result["records"].get(col_name, {})
 
@@ -2203,15 +2203,15 @@ elif page == "🌿 Version Control":
                             st.rerun()
                 else:
                     st.success("No conflicts detected — safe to merge.")
-                    if tensors_with_delete_diffs:
+                    if columns_with_delete_diffs:
                         st.caption(
                             "This merge still includes one-sided deletes. Choose how delete records should apply."
                         )
                         delete_rows = []
-                        for col_name in sorted(tensors_with_delete_diffs):
+                        for col_name in sorted(columns_with_delete_diffs):
                             cdata = result["records"].get(col_name, {})
                             delete_rows.append({
-                                "Tensor": col_name,
+                                "Column": col_name,
                                 "Current-only deletes": len(set(cdata.get("del_ori_idx") or [])),
                                 "Source-only deletes": len(set(cdata.get("del_tar_idx") or [])),
                             })
@@ -2263,11 +2263,11 @@ elif page == "⚡ Benchmarks":
         ds = st.session_state.dataset
         st.subheader("MULLER vs Parquet: Query Performance & Storage")
 
-        tensor_names = list(ds.tensors.keys())
+        column_names = list(ds.columns.keys())
 
         col1, col2, col3 = st.columns(3)
         with col1:
-            bm_field = st.selectbox("Field", tensor_names, key="bm_field")
+            bm_field = st.selectbox("Field", column_names, key="bm_field")
         with col2:
             bm_op = st.selectbox("Operator", [">", "<", "==", ">=", "<=", "!="], key="bm_op")
         with col3:
@@ -2326,9 +2326,9 @@ elif page == "ℹ️ About":
 
 ```
 Dataset
-├── Tensor (column)
+├── Column
 │   ├── ChunkEngine (variable-sized chunks)
-│   └── TensorMeta (htype, dtype, compression)
+│   └── TensorMeta (internal storage metadata)
 ├── VersionControl
 │   ├── CommitDAG
 │   └── MergeStrategies (ours / theirs / both)

--- a/streamlit_ui/utils.py
+++ b/streamlit_ui/utils.py
@@ -127,7 +127,7 @@ except ImportError:
     ImageDraw = None  # type: ignore
     ImageFont = None  # type: ignore
 
-# Canonical COCO2017 tensors (as produced by official_demo.ipynb and the
+# Canonical COCO2017 columns (as produced by official_demo.ipynb and the
 # muller_datasetcoco export). The SIGMOD demo schema extends this with
 # `description` (text, derived from category_id), and downstream code paths
 # may want to attach even more derived columns — so we treat the set below
@@ -191,9 +191,12 @@ def _is_image_htype(ht: Any) -> bool:
     return False
 
 
-def list_image_tensor_names(ds: Any) -> List[str]:
-    """Tensor names whose htype stores image samples (for Streamlit preview)."""
-    return [n for n, t in ds.tensors.items() if _is_image_htype(t.htype)]
+def list_image_column_names(ds: Any) -> List[str]:
+    """Column names whose htype stores image samples (for Streamlit preview)."""
+    return [n for n, t in ds.columns.items() if _is_image_htype(t.htype)]
+
+
+list_image_tensor_names = list_image_column_names
 
 
 def decode_muller_image_sample(v: Any) -> Optional[Any]:
@@ -312,14 +315,14 @@ def pil_fit_inside(
 
 
 def is_coco2017_muller_schema(ds: Any) -> bool:
-    """True if the dataset carries the 8 canonical COCO2017 tensors.
+    """True if the dataset carries the 8 canonical COCO2017 columns.
 
     We use a *superset* check (not equality) so datasets with extra derived
-    columns — e.g. the SIGMOD demo adds a ``description`` text tensor — are
+    columns — e.g. the SIGMOD demo adds a ``description`` text column — are
     still recognised as COCO-style and get the bbox-overlay / thumbnail-grid
-    UI treatment. The ``_uuid`` bookkeeping tensor is ignored either way.
+    UI treatment. The ``_uuid`` bookkeeping column is ignored either way.
     """
-    names = set(ds.tensors.keys())
+    names = set(ds.columns.keys())
     names.discard("_uuid")
     return COCO2017_MULLER_SCHEMA.issubset(names)
 
@@ -445,22 +448,25 @@ def create_dataset(name: str, root: str, overwrite: bool = False) -> Tuple[Optio
         return None, f"Failed to create dataset: {e}"
 
 
-def create_tensors(ds: Any, schema: Dict[str, Dict[str, Any]]) -> Optional[str]:
-    """Create tensors (columns) in the dataset.
+def create_columns(ds: Any, schema: Dict[str, Dict[str, Any]]) -> Optional[str]:
+    """Create columns in the dataset.
 
-    schema: {tensor_name: {htype, dtype, sample_compression}}
+    schema: {column_name: {htype, dtype, sample_compression}}
     """
     try:
-        for tensor_name, config in schema.items():
+        for column_name, config in schema.items():
             kwargs = {"htype": config.get("htype", "generic")}
             if config.get("dtype"):
                 kwargs["dtype"] = config["dtype"]
             if config.get("sample_compression"):
                 kwargs["sample_compression"] = config["sample_compression"]
-            ds.create_tensor(tensor_name, **kwargs)
+            ds.create_column(column_name, **kwargs)
         return None
     except Exception as e:
-        return f"Failed to create tensors: {e}"
+        return f"Failed to create columns: {e}"
+
+
+create_tensors = create_columns
 
 
 def add_samples(
@@ -469,11 +475,11 @@ def add_samples(
     auto_commit: bool = True,
     commit_message: Optional[str] = None,
 ) -> Optional[str]:
-    """Add samples to dataset using per-tensor extend."""
+    """Add samples to dataset using per-column extend."""
     try:
         with ds:
-            for tensor_name, values in data.items():
-                ds[tensor_name].extend(values)
+            for column_name, values in data.items():
+                ds[column_name].extend(values)
         if auto_commit:
             ds.commit(message=commit_message or "Add samples via Streamlit UI")
         return None
@@ -481,10 +487,10 @@ def add_samples(
         return f"Failed to add samples: {e}"
 
 
-def update_sample(ds: Any, tensor_name: str, index: int, value: Any) -> Optional[str]:
+def update_sample(ds: Any, column_name: str, index: int, value: Any) -> Optional[str]:
     """Update a single sample value."""
     try:
-        ds[tensor_name][index] = value
+        ds[column_name][index] = value
         return None
     except Exception as e:
         return f"Failed to update sample: {e}"
@@ -499,9 +505,9 @@ def delete_sample(ds: Any, index: int) -> Optional[str]:
         return f"Failed to delete sample: {e}"
 
 
-def _inverted_index_has_field(ds: Any, tensor_column: str) -> bool:
+def _inverted_index_has_field(ds: Any, column_name: str) -> bool:
     """Return True iff ``inverted_index_dir_vec/<branch>/meta.json`` has an
-    entry for ``tensor_column`` (the source of truth used by
+    entry for ``column_name`` (the source of truth used by
     ``filter_vectorized`` to decide whether an index exists)."""
     branch = ds.version_state.get("branch", "main")
     meta_path = os.path.join("inverted_index_dir_vec", branch, "meta.json")
@@ -513,7 +519,7 @@ def _inverted_index_has_field(ds: Any, tensor_column: str) -> bool:
         meta = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
     except Exception:
         return False
-    return isinstance(meta, dict) and tensor_column in meta
+    return isinstance(meta, dict) and column_name in meta
 
 
 def _try_make_writable(ds: Any) -> bool:
@@ -537,10 +543,10 @@ def _try_make_writable(ds: Any) -> bool:
 
 def ensure_inverted_index(
     ds: Any,
-    tensor_column: str,
+    column_name: str,
     progress_cb: Optional[Callable[[str], None]] = None,
 ) -> Optional[str]:
-    """Make sure a vectorized inverted index exists for ``tensor_column``.
+    """Make sure a vectorized inverted index exists for ``column_name``.
 
     - No-op if an entry already exists in the meta.json.
     - Requires a writable dataset: ``create_index_vectorized`` spawns worker
@@ -552,17 +558,17 @@ def ensure_inverted_index(
     - Auto-commits pending changes first, because ``create_index_vectorized``
       silently skips (only ``warnings.warn``) when ``ds.has_head_changes`` is True.
     - Verifies via meta.json that the index was actually written, so any other
-      silent failure (empty tensor, unsupported htype, worker crash) surfaces
+      silent failure (empty column, unsupported htype, worker crash) surfaces
       as an error string instead of pretending success.
 
     Returns ``None`` on success; returns an error string on failure.
     """
-    if _inverted_index_has_field(ds, tensor_column):
+    if _inverted_index_has_field(ds, column_name):
         return None
 
     if getattr(ds, "read_only", False) and not _try_make_writable(ds):
         return (
-            f"Cannot create inverted index for '{tensor_column}': the dataset "
+            f"Cannot create inverted index for '{column_name}': the dataset "
             "is loaded in read-only mode (its write lock is held by another "
             "MULLER process or a stale session). Please close any other "
             "process that has this dataset open and re-load it here."
@@ -570,18 +576,18 @@ def ensure_inverted_index(
 
     try:
         if progress_cb is not None:
-            progress_cb(tensor_column)
+            progress_cb(column_name)
         if ds.has_head_changes:
-            ds.commit(message=f"Auto-commit before inverted index for '{tensor_column}'")
-        ds.create_index_vectorized(tensor_column)
+            ds.commit(message=f"Auto-commit before inverted index for '{column_name}'")
+        ds.create_index_vectorized(column_name)
     except Exception as e:
-        return f"Failed to create inverted index for '{tensor_column}': {e}"
+        return f"Failed to create inverted index for '{column_name}': {e}"
 
-    if not _inverted_index_has_field(ds, tensor_column):
+    if not _inverted_index_has_field(ds, column_name):
         return (
-            f"Inverted index creation for '{tensor_column}' did not complete "
+            f"Inverted index creation for '{column_name}' did not complete "
             "(no entry recorded in meta.json). Most common causes: (a) the "
-            "tensor is empty, (b) its htype/dtype is unsupported — CONTAINS "
+            "column is empty, (b) its htype/dtype is unsupported — CONTAINS "
             "indexing requires htype `text`/`class_label` or dtype `int64`/"
             "`float64`, (c) the dataset is read-only (check `ds.read_only`)."
         )
@@ -621,7 +627,7 @@ def run_query(ds: Any, conditions: List[Tuple[str, str, Any]],
             if not auto_create_index:
                 return None, f"Query failed: {e}"
             # Find the next CONTAINS field that is missing from meta.json and
-            # that we have not already attempted. Prefer the tensor named in
+            # that we have not already attempted. Prefer the column named in
             # the exception message when available, to match the backend's view.
             err_text = str(e)
             ordered_candidates = sorted(
@@ -647,12 +653,12 @@ def run_query(ds: Any, conditions: List[Tuple[str, str, Any]],
     return None, "Query failed: exceeded retry budget while auto-building inverted indexes."
 
 
-def dataset_to_dataframe(ds: Any, tensor_list: Optional[List[str]] = None,
+def dataset_to_dataframe(ds: Any, columns: Optional[List[str]] = None,
                          start: int = 0, end: Optional[int] = None) -> Tuple[Optional[pd.DataFrame], Optional[str]]:
     """Convert dataset (or view) to pandas DataFrame.
 
     Uses the sliced *view* for the fallback path so only ``end - start`` rows are
-    materialized (avoids loading entire tensors for pagination).
+    materialized (avoids loading entire columns for pagination).
     """
     try:
         if end is not None:
@@ -661,7 +667,7 @@ def dataset_to_dataframe(ds: Any, tensor_list: Optional[List[str]] = None,
             view = ds[start:]
         else:
             view = ds
-        df = view.to_dataframe(tensor_list=tensor_list)
+        df = view.to_dataframe(columns=columns)
         return df, None
     except Exception:
         try:
@@ -671,13 +677,13 @@ def dataset_to_dataframe(ds: Any, tensor_list: Optional[List[str]] = None,
                 view = ds[start:]
             else:
                 view = ds
-            if tensor_list is None:
-                tensor_list = list(view.tensors.keys())
+            if columns is None:
+                columns = list(view.columns.keys())
             data = {}
-            for tname in tensor_list:
-                tensor = view[tname]
-                vals = tensor.numpy(aslist=True)
-                data[tname] = vals
+            for column_name in columns:
+                column = view[column_name]
+                vals = column.numpy(aslist=True)
+                data[column_name] = vals
             return pd.DataFrame(data), None
         except Exception as e2:
             return None, f"Failed to convert to DataFrame: {e2}"
@@ -1415,18 +1421,21 @@ def _is_vector_like_htype(ht: Any) -> bool:
     return h in ("embedding", "vector")
 
 
-def list_vector_tensor_names(ds: Any) -> List[str]:
-    """Tensor names that can be used as vector-search targets.
+def list_vector_column_names(ds: Any) -> List[str]:
+    """Column names that can be used as vector-search targets.
 
-    Returns tensors whose declared ``htype`` is ``embedding``/``vector``, plus
-    any 1-D float tensor that *could* be treated as an embedding column.
+    Returns columns whose declared ``htype`` is ``embedding``/``vector``, plus
+    any 1-D float column that *could* be treated as an embedding column.
     The first group is preferred; callers may display them distinctly.
     """
     names: List[str] = []
-    for n, t in ds.tensors.items():
+    for n, t in ds.columns.items():
         if _is_vector_like_htype(t.htype):
             names.append(n)
     return names
+
+
+list_vector_tensor_names = list_vector_column_names
 
 
 def list_vector_indexes(ds: Any) -> Dict[str, List[str]]:
@@ -1435,7 +1444,7 @@ def list_vector_indexes(ds: Any) -> Dict[str, List[str]]:
     The vector-index layout (see ``TensorVectorIndex._init_tensor_index``):
         <ds.path>/_vector_index/<branch>/<tensor_key>/<index_name>/
 
-    Returns ``{tensor_name: [index_name, ...]}``. Empty dict if the
+    Returns ``{column_name: [index_name, ...]}``. Empty dict if the
     ``_vector_index`` directory does not exist yet.
     """
     out: Dict[str, List[str]] = {}
@@ -1481,15 +1490,15 @@ def parse_query_vector(text: str, expected_dim: Optional[int] = None) -> Tuple[O
     if expected_dim is not None and vec.shape[0] != expected_dim:
         return None, (
             f"Dimension mismatch: got {vec.shape[0]} values, "
-            f"but tensor expects {expected_dim}."
+            f"but column expects {expected_dim}."
         )
     return vec, None
 
 
-def tensor_embedding_dim(ds: Any, tensor_name: str) -> Optional[int]:
-    """Best-effort embedding dimension for ``tensor_name`` (for input validation)."""
+def column_embedding_dim(ds: Any, column_name: str) -> Optional[int]:
+    """Best-effort embedding dimension for ``column_name`` (for input validation)."""
     try:
-        t = ds.tensors.get(tensor_name)
+        t = ds.columns.get(column_name)
         if t is None:
             return None
         shp = getattr(t, "shape", None)
@@ -1506,9 +1515,12 @@ def tensor_embedding_dim(ds: Any, tensor_name: str) -> Optional[int]:
     return None
 
 
-def _uuids_to_positions(ds: Any, tensor_name: str, uuids: Any) -> List[int]:
+tensor_embedding_dim = column_embedding_dim
+
+
+def _uuids_to_positions(ds: Any, column_name: str, uuids: Any) -> List[int]:
     """Map sample-uuid results from FAISS back to positional row indexes."""
-    t = ds.tensors.get(tensor_name)
+    t = ds.columns.get(column_name)
     if t is None:
         return []
     try:
@@ -1529,7 +1541,7 @@ def _uuids_to_positions(ds: Any, tensor_name: str, uuids: Any) -> List[int]:
 
 def run_vector_search(
     ds: Any,
-    tensor_name: str,
+    column_name: str,
     index_name: str,
     query_vector: np.ndarray,
     topk: int = 10,
@@ -1548,21 +1560,21 @@ def run_vector_search(
     """
     try:
         try:
-            ds.load_vector_index(tensor_name, index_name)
+            ds.load_vector_index(column_name, index_name)
         except Exception as e:
             return None, None, None, (
                 f"Failed to load vector index '{index_name}' on "
-                f"'{tensor_name}': {e}"
+                f"'{column_name}': {e}"
             )
         qv = np.asarray(query_vector, dtype=np.float32).reshape(1, -1)
-        dist, ids = ds.vector_search(qv, tensor_name, index_name, topk=topk)
+        dist, ids = ds.vector_search(qv, column_name, index_name, topk=topk)
         dist_arr = np.asarray(dist).reshape(-1)
         id_arr = np.asarray(ids).reshape(-1)
         # Drop FAISS sentinel values for "no neighbour" (-1).
         keep = id_arr != -1
         id_arr = id_arr[keep]
         dist_arr = dist_arr[keep] if dist_arr.shape[0] == keep.shape[0] else dist_arr
-        positions = _uuids_to_positions(ds, tensor_name, id_arr)
+        positions = _uuids_to_positions(ds, column_name, id_arr)
         if not positions:
             # Fall back to interpreting ids as positional indexes (some index
             # backends might already return positions).
@@ -1587,7 +1599,7 @@ def run_vector_search(
 
 def ensure_vector_index(
     ds: Any,
-    tensor_name: str,
+    column_name: str,
     index_name: str,
     index_type: str = "FLAT",
     metric: str = "l2",
@@ -1599,17 +1611,17 @@ def ensure_vector_index(
     ``ds.has_head_changes``).
     """
     _existing = list_vector_indexes(ds)
-    if index_name in _existing.get(tensor_name, []):
+    if index_name in _existing.get(column_name, []):
         return None
     if getattr(ds, "read_only", False) and not _try_make_writable(ds):
         return (
-            f"Cannot create vector index '{index_name}' on '{tensor_name}': "
+            f"Cannot create vector index '{index_name}' on '{column_name}': "
             "dataset is read-only."
         )
     try:
         if ds.has_head_changes:
             ds.commit(message=f"Auto-commit before building vector index '{index_name}'")
-        ds.create_vector_index(tensor_name, index_name, index_type=index_type, metric=metric)
+        ds.create_vector_index(column_name, index_name, index_type=index_type, metric=metric)
     except Exception as e:
         return f"Failed to create vector index: {e}"
     return None
@@ -1722,11 +1734,13 @@ def delete_saved_view(ds: Any, view_id: str) -> Optional[str]:
 def get_dataset_info(ds: Any) -> Dict[str, Any]:
     """Return summary info about the dataset."""
     try:
+        columns = {name: {"htype": t.htype, "dtype": str(t.dtype)} for name, t in ds.columns.items()}
         return {
             "path": ds.path,
             "branch": ds.branch,
             "num_samples": len(ds),
-            "tensors": {name: {"htype": t.htype, "dtype": str(t.dtype)} for name, t in ds.tensors.items()},
+            "columns": columns,
+            "tensors": columns,
             "commit_id": ds.commit_id,
             "has_uncommitted": ds.has_head_changes,
         }


### PR DESCRIPTION
## Summary

- Adds column-first public API aliases such as `create_column`, `delete_column`, `rename_column`, `columns`, and related query/export/indexing parameters while preserving existing tensor-based APIs for compatibility.
- Updates README, docs, `.claude/skills`, and Streamlit UI copy/examples to present dataset fields as columns instead of tensors.
- Keeps internal tensor storage metadata and persisted dataset format unchanged, including `tensor_meta.json` and existing tensor-based internal structures.

## Test Plan

- Ran Python compile checks for changed Python files.
- Ran smoke tests for the new column aliases on `Dataset`.
- Ran smoke tests for `.claude/skills/muller-dataset/scripts/dataset_manager.py` with `--columns` and `create-column`.
- Checked lints for modified Python files.