### PR TITLE
Fix vector index backend reliability and optional DiskANN support

### DIFF
--- a/muller/core/vector/algorithms/diskann_index.py
+++ b/muller/core/vector/algorithms/diskann_index.py
@@ -11,20 +11,33 @@ import importlib
 import logging
 from abc import abstractmethod
 from pathlib import Path
-from typing import Union, Tuple
+from typing import Union, Tuple, TYPE_CHECKING
 
 import numpy as np
 from numpy._typing import NDArray
-from torch import Tensor
+
+if TYPE_CHECKING:
+    from torch import Tensor
+else:
+    Tensor = object
 
 import muller.core.vector.index_param as IndexParam
 from muller.core.vector.exceptions import SearchError
 
 dap = None
+_diskann_import_error = None
 try:
     dap = importlib.import_module("diskannpy")
 except ImportError as err:
-    print("diskannpy not found")
+    _diskann_import_error = err
+
+
+def _require_diskann():
+    if dap is None:
+        raise ModuleNotFoundError(
+            "please install dependency for DISKANN vector index first: diskannpy"
+        ) from _diskann_import_error
+    return dap
 
 
 class DiskANNVectorIndex:
@@ -33,7 +46,7 @@ class DiskANNVectorIndex:
     @abstractmethod
     def search(
         cls,
-        index: dap.StaticDiskIndex,
+        index: "dap.StaticDiskIndex",
         query_vector: Union[NDArray[np.float32], Tensor],
         metric: str,
         **search_param,
@@ -70,7 +83,7 @@ class DiskANNVectorIndex:
         pass
 
     @classmethod
-    def load(cls, **kwargs) -> dap.StaticDiskIndex:
+    def load(cls, **kwargs) -> "dap.StaticDiskIndex":
         """
         Default method for load DiskANN vector index.
         Args:
@@ -79,8 +92,9 @@ class DiskANNVectorIndex:
         Returns:
 
         """
+        diskann = _require_diskann()
         param = IndexParam.LoadDiskANN.model_validate(kwargs)
-        return dap.StaticDiskIndex(
+        return diskann.StaticDiskIndex(
             index_directory=str(param.path),
             num_threads=param.num_threads,
             num_nodes_to_cache=param.num_nodes_to_cache,
@@ -109,16 +123,17 @@ class StaticDiskIndex(DiskANNVectorIndex):
         **index_param,
     ):
         param = IndexParam.CreateDiskANN.model_validate(index_param)
+        diskann = _require_diskann()
         path = Path(param.path)
         if not path.exists():
             path.mkdir(parents=True)
         vector_path = str(path / "ann_vectors.bin")
         dtype = vector_array.dtype
-        dap.vectors_to_file(vector_file=vector_path, vectors=vector_array)
+        diskann.vectors_to_file(vector_file=vector_path, vectors=vector_array)
         logging.info("Finish save vectors to file.")
         del vector_array
         gc.collect()
-        dap.build_disk_index(
+        diskann.build_disk_index(
             data=vector_path,
             vector_dtype=dtype,
             distance_metric=metric,
@@ -131,7 +146,7 @@ class StaticDiskIndex(DiskANNVectorIndex):
             pq_disk_bytes=param.pq_disk_bytes,
         )
         return (
-            dap.StaticDiskIndex(
+            diskann.StaticDiskIndex(
                 index_directory=param.path,
                 num_threads=param.num_threads,
                 num_nodes_to_cache=param.num_nodes_to_cache,
@@ -142,7 +157,7 @@ class StaticDiskIndex(DiskANNVectorIndex):
     @classmethod
     def search(
         cls,
-        index: dap.StaticDiskIndex,
+        index: "dap.StaticDiskIndex",
         query_vector: NDArray[np.float32],
         metric: str,
         **search_param,

--- a/muller/core/vector/algorithms/faiss_index.py
+++ b/muller/core/vector/algorithms/faiss_index.py
@@ -7,16 +7,25 @@
 # Copyright (c) 2026 Xueling Lin
 
 import logging
+import os
+import sys
 from abc import abstractmethod
-from typing import Union, Tuple
+from typing import Union, Tuple, TYPE_CHECKING
 
+if sys.platform == "darwin":
+    # See muller.core.vector.utils for context. Keep this before importing FAISS.
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 try:
     import faiss
-except ImportError:
-    print("faiss not found")
+except ImportError as err:
+    raise ModuleNotFoundError("please install dependency for vector search first: faiss-cpu") from err
 import numpy as np
 from numpy._typing import NDArray
-from torch import Tensor
+
+if TYPE_CHECKING:
+    from torch import Tensor
+else:
+    Tensor = object
 
 import muller.core.vector.index_param as IndexParam
 from muller.core.vector.exceptions import FaissIndexError
@@ -133,7 +142,7 @@ class IVFPQIndex(FaissVectorIndex):
                 FaissVectorIndex._get_faiss_metric(metric),
             )
             vector_index.train(x=vector_array)
-            vector_index.add(vector_array)
+            vector_index.add_with_ids(vector_array, id_array.astype(np.int64, copy=False))
         except KeyError:
             logging.error(f"Get invalid metric: {metric}")
         return vector_index, param.__dict__
@@ -148,10 +157,10 @@ class IVFPQIndex(FaissVectorIndex):
     ) -> Tuple[NDArray[np.float32], NDArray[np.uint64]]:
         # verify parameter
         param = IndexParam.SearchIVFPQ.model_validate(search_param)
+        query_vector = np.ascontiguousarray(query_vector, dtype=np.float32)
         if metric == "cosine":
             faiss.normalize_L2(query_vector)
         index.nprobe = param.nprobe
-        index.k_factor = param.refine_factor
         dist_list: NDArray[np.float32]
         id_list: NDArray[np.int64]
         dist_list, id_list = index.search(x=query_vector, k=param.topk)
@@ -175,7 +184,8 @@ class FlatIndex(FaissVectorIndex):
             vector_index = faiss.IndexFlat(
                 dimension, FaissVectorIndex._get_faiss_metric(metric)
             )
-            vector_index.add(vector_array)
+            vector_index = faiss.IndexIDMap(vector_index)
+            vector_index.add_with_ids(vector_array, id_array.astype(np.int64, copy=False))
         except KeyError:
             logging.error(f"get invalid metric")
         return vector_index, {}
@@ -190,6 +200,7 @@ class FlatIndex(FaissVectorIndex):
     ) -> Tuple[NDArray[np.float32], NDArray[np.uint64]]:
         # verify parameter
         param = IndexParam.SearchFLAT.model_validate(search_param)
+        query_vector = np.ascontiguousarray(query_vector, dtype=np.float32)
         if metric == "cosine":
             faiss.normalize_L2(query_vector)
         dist_list: NDArray[np.float32]
@@ -214,12 +225,13 @@ class HNSWFLATIndex(FaissVectorIndex):
         if metric == "cosine":
             faiss.normalize_L2(vector_array)
 
-        vector_index = faiss.IndexHNSWFlat(
+        base_index = faiss.IndexHNSWFlat(
             dimension, param.m, FaissVectorIndex._get_faiss_metric(metric)
         )
-        vector_index.hnsw.efConstruction = param.ef_construction
-        vector_index.train(x=vector_array)
-        vector_index.add(vector_array)
+        base_index.hnsw.efConstruction = param.ef_construction
+        base_index.train(x=vector_array)
+        vector_index = faiss.IndexIDMap(base_index)
+        vector_index.add_with_ids(vector_array, id_array.astype(np.int64, copy=False))
 
         return vector_index, param.__dict__
 
@@ -233,6 +245,7 @@ class HNSWFLATIndex(FaissVectorIndex):
     ) -> Tuple[NDArray[np.float32], NDArray[np.uint64]]:
         # verify parameter
         param = IndexParam.SearchHNSW.model_validate(search_param)
+        query_vector = np.ascontiguousarray(query_vector, dtype=np.float32)
         if metric == "cosine":
             faiss.normalize_L2(query_vector)
         faiss.ParameterSpace().set_index_parameter(index, "efSearch", param.ef_search)

--- a/muller/core/vector/utils.py
+++ b/muller/core/vector/utils.py
@@ -7,11 +7,17 @@
 # Copyright (c) 2026 Xueling Lin
 
 import importlib
+import os
+import sys
 
+if sys.platform == "darwin":
+    # FAISS and PyTorch wheels can load separate OpenMP runtimes on macOS.
+    # This must be set before FAISS imports libomp.
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 try:
     import faiss
-except ImportError:
-    print("faiss not found")
+except ImportError as err:
+    raise ModuleNotFoundError("please install dependency for vector search first: faiss-cpu") from err
 import numpy as np
 from numpy._typing import NDArray
 

--- a/muller/core/vector/vector_index.py
+++ b/muller/core/vector/vector_index.py
@@ -10,10 +10,9 @@ import json
 import logging
 import shutil
 from pathlib import Path
-from typing import Dict, Union, List, Tuple
+from typing import Dict, Union, List, Tuple, TYPE_CHECKING
 
 import numpy as np
-import torch
 from numpy.typing import NDArray
 
 from muller.core.tensor import Tensor
@@ -28,6 +27,14 @@ from .exceptions import (
     IndexNotLoadError,
     CreateIndexError,
 )
+
+if TYPE_CHECKING:
+    import torch
+else:
+    class _TorchModule:
+        Tensor = object
+
+    torch = _TorchModule()
 
 
 class VectorIndex:
@@ -214,6 +221,8 @@ class VectorIndex:
         commit_id = param.get("commit_id")
         if commit_id is None:
             raise CreateIndexError("commit_id cannot be None.")
+        vector_array = np.ascontiguousarray(vector_array, dtype=np.float32)
+        id_array = np.ascontiguousarray(id_array, dtype=np.int64)
         dimension = vector_array.shape[1]
         index_creator = utils.load_algo(index_type)
         param.update({"path": str(self.path)})
@@ -252,7 +261,7 @@ class VectorIndex:
             index_algo = utils.load_algo(self.index_type)
             refine_factor = search_param.get("refine_factor", 1)
             topk = search_param.get("topk", 1)
-            search_param["topk"] = topk * refine_factor
+            search_param["topk"] = int(topk * refine_factor)
             dist_list, id_list = index_algo.search(
                 self._index, query_array, self._meta["metric"], **search_param
             )
@@ -267,19 +276,23 @@ class VectorIndex:
         """
         shutil.rmtree(self.path)
 
-    def add_data(self, input_array: NDArray[np.float32]):
+    def add_data(self, input_array: NDArray[np.float32], id_array: NDArray[np.int64]):
         """
         Add data into the vector index.
         Args:
             input_array: 1-d ndarray of vector to append into index.
+            id_array: 1-d ndarray of ids for the appended vectors.
         """
         if len(input_array.shape) > 2:
             raise CreateIndexError(
                 f"unexpect input_array format with shape {input_array.shape}"
             )
 
+        input_array = np.ascontiguousarray(input_array, dtype=np.float32)
+        id_array = np.ascontiguousarray(id_array, dtype=np.int64)
+
         if input_array.shape[1] == self._meta["dimension"]:
-            self._index.add(input_array)
+            self._index.add_with_ids(input_array, id_array)
         else:
             raise IndexAddDataError(
                 f"Add data to index error, cause input array with {input_array.shape[1]}, "
@@ -342,13 +355,8 @@ class TensorVectorIndex:
         uuid_list: NDArray[np.uint64], tensor: Tensor
     ) -> NDArray[np.uint64]:
         tensor_uuid_list = tensor._sample_id_tensor.numpy().flatten()
-        res_id = []
-        for uuid_q in uuid_list:
-            id_list = []
-            for uuid in uuid_q:
-                id_list.append(np.where(tensor_uuid_list == uuid))
-            res_id.append(id_list)
-        return np.array(res_id)
+        uuid_to_pos = {str(uuid): pos for pos, uuid in enumerate(tensor_uuid_list)}
+        return np.array([uuid_to_pos[str(uuid)] for uuid in uuid_list], dtype=np.int64)
 
     @staticmethod
     def _refine_result(
@@ -363,19 +371,22 @@ class TensorVectorIndex:
         # calculate real top-k nearest distance list for each query
         for i in range(query_vectors.shape[0]):
             # get origin vectors from id list
-            vectors: NDArray[np.uint32, np.float32] = tensor[
-                id_list[i].tolist()
-            ].numpy()
+            candidate_ids = id_list[i]
+            vectors: NDArray[np.uint32, np.float32] = tensor[candidate_ids.tolist()].numpy()
             # calculate the distance list between query_vector and origin vectors
             dist_list: NDArray[np.float32] = utils.cal_distance(
                 metric_type, query_vectors[i], vectors
             )
             # select the top-k nearest subscript.
-            nn_dist_list = np.argpartition(a=dist_list, kth=topk)[:topk]
+            if len(dist_list) <= topk:
+                nn_dist_list = np.argsort(dist_list)
+            else:
+                nn_dist_list = np.argpartition(a=dist_list, kth=topk - 1)[:topk]
+                nn_dist_list = nn_dist_list[np.argsort(dist_list[nn_dist_list])]
             # map the top-k nearest subscript to original id
-            topk_ids = id_list[i][nn_dist_list]
+            topk_ids = candidate_ids[nn_dist_list]
             topk_id_list.append(topk_ids)
-            topk_dist_list.append(dist_list)
+            topk_dist_list.append(dist_list[nn_dist_list])
 
         return np.array(topk_dist_list), np.array(topk_id_list)
 
@@ -402,9 +413,10 @@ class TensorVectorIndex:
         overwrite = create_param.get("overwrite", False)
         vector_index = VectorIndex(self.path, tensor.key, index_name)
         if overwrite or not vector_index.is_exist:
+            vector_array = tensor.numpy()
             vector_index.build_index(
-                vector_array=tensor.numpy(),
-                id_array=tensor._sample_id_tensor.numpy().flatten(),
+                vector_array=vector_array,
+                id_array=np.arange(vector_array.shape[0], dtype=np.int64),
                 index_type=index_type,
                 metric=metric,
                 **create_param,
@@ -494,9 +506,14 @@ class TensorVectorIndex:
         vector_index = self.get_vector_index(tensor, index_name)
         vector_index.unload()
         vector_index.drop()
+        tensor_indexes = self._index_map.get(tensor.key, {})
+        tensor_indexes.pop(index_name, None)
         # if drop the last index of tensor, remove tensor level directory
-        if len(self._index_map.get(tensor.key, {})) == 0:
-            (self.path / tensor.key).rmdir()
+        if len(tensor_indexes) == 0:
+            self._index_map.pop(tensor.key, None)
+            tensor_path = self.path / tensor.key
+            if tensor_path.exists():
+                tensor_path.rmdir()
 
     def update_index(
         self,
@@ -517,10 +534,17 @@ class TensorVectorIndex:
         vector_index = self.get_vector_index(tensor, index_name)
         if not vector_index.is_loaded:
             raise IndexNotLoadError(tensor_name=tensor.key, index_name=index_name)
+        added_items = list(tensor_changes["added"].items())
+        if not added_items:
+            vector_index.commit_id = new_commit_id
+            return
         data_array: NDArray[np.float32] = np.array(
-            list(tensor_changes["added"].values()), dtype=np.float32
+            [value for _, value in added_items], dtype=np.float32
         )
-        vector_index.add_data(data_array)
+        current_uuids = tensor._sample_id_tensor.numpy().flatten()
+        uuid_to_pos = {str(uuid): pos for pos, uuid in enumerate(current_uuids)}
+        id_array = np.array([uuid_to_pos[str(uuid)] for uuid, _ in added_items], dtype=np.int64)
+        vector_index.add_data(data_array, id_array)
         vector_index.commit_id = new_commit_id
 
     def _init_tensor_index(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ demo = [
     "streamlit>=1.30",
     "plotly"
 ]
+# DISKANN is an optional vector index backend. The upstream diskannpy wheels
+# are not available for macOS, and diskannpy 0.7.0 pins numpy==1.25, so keep it
+# limited to Linux + Python 3.11. macOS users need to build DiskANN/diskannpy
+# from source instead of installing this extra.
+diskann = [
+    "diskannpy==0.7.0; platform_system == 'Linux' and python_version == '3.11'"
+]
 
 [tool.setuptools]
 zip-safe = false

--- a/tests/integration/indexing/test_vector_index.py
+++ b/tests/integration/indexing/test_vector_index.py
@@ -7,6 +7,7 @@
 # Copyright (c) 2026 Xueling Lin
 
 import gc
+import importlib.util
 import logging
 import os
 import shutil
@@ -20,6 +21,11 @@ import muller
 from muller.core.vector.exceptions import SearchError
 from tests.constants import SMALL_TEST_PATH
 from tests.utils import official_path, check_skip_vector_index_test
+
+DISKANNPY_AVAILABLE = importlib.util.find_spec("diskannpy") is not None
+DISKANNPY_SKIP = pytest.mark.skipif(
+    not DISKANNPY_AVAILABLE, reason="diskannpy is required for DISKANN vector index tests"
+)
 
 
 @pytest.mark.skipif(
@@ -45,7 +51,12 @@ class TestCpuVectorIndex:
         [
             ["flat", "FLAT", np.random.rand(1, 3).astype(np.float32)],
             ["hnsw", "HNSWFLAT", np.random.rand(1, 3).astype(np.float32)],
-            ["disk_ann", "DISKANN", np.random.rand(3).astype(np.float32)],
+            pytest.param(
+                "disk_ann",
+                "DISKANN",
+                np.random.rand(3).astype(np.float32),
+                marks=DISKANNPY_SKIP,
+            ),
         ],
     )
     def test_simple(
@@ -78,7 +89,12 @@ class TestCpuVectorIndex:
         [
             ["flat", "FLAT", np.random.rand(1, 3).astype(np.float32)],
             ["hnsw", "HNSWFLAT", np.random.rand(1, 3).astype(np.float32)],
-            ["disk_ann", "DISKANN", np.random.rand(3).astype(np.float32)],
+            pytest.param(
+                "disk_ann",
+                "DISKANN",
+                np.random.rand(3).astype(np.float32),
+                marks=DISKANNPY_SKIP,
+            ),
         ],
     )
     def test_unload(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,10 +9,7 @@
 import os
 import sys
 
-import torch
-from torchvision.datasets import CIFAR10
 from pathlib import Path
-from torch.utils.data import Dataset
 from .constants import LOCAL_DATA_DIR, HUASHAN_DATA_DIR
 
 DATA_DIR = Path(LOCAL_DATA_DIR)
@@ -80,7 +77,7 @@ def get_size(mode="train"):
             return VAL_SIZE
 
 
-class Cifar10Dataset(Dataset):
+class Cifar10Dataset:
     """Face Landmarks dataset."""
 
     def __init__(self, root_dir, mode, train=True, download=False):
@@ -100,6 +97,8 @@ class Cifar10Dataset(Dataset):
             return get_size("test")
 
     def _download(self):
+        from torchvision.datasets import CIFAR10
+
         original_path = self.root_dir.parent / f"original_{'train' if self.is_train else 'test'}"
         ds = CIFAR10(original_path, train=self.is_train, download=True)
         self.root_dir.mkdir(parents=True, exist_ok=True)
@@ -131,6 +130,8 @@ class Cifar10Dataset(Dataset):
 
 
 def get_cifar10(mode="train", download=True):
+    import torch
+
     is_train = mode in ["train", "val"]  # TODO: why?
     path = DATA_DIR
     if is_train:


### PR DESCRIPTION
## Summary

- Fixed vector index test/runtime failures caused by eager `torch` imports conflicting with FAISS/OpenMP on macOS.
- Made `diskannpy` an optional backend dependency and skipped DISKANN tests when it is unavailable.
- Fixed FAISS vector index behavior around explicit IDs, incremental updates, dropped index cache cleanup, and `refine_factor` result handling.
- Added a `diskann` optional dependency extra for Linux + Python 3.11 environments.

## Test Plan

- `python -m pytest -q tests/integration/indexing/test_vector_index.py tests/integration/indexing/test_vector_search_recall.py --vector_index_test local -rs`

Result: `10 passed, 2 skipped`

The skipped tests are DISKANN cases on environments where `diskannpy` is not installed.