### PR TITLE
Title: Pin faiss-cpu to NumPy 1.25-compatible release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "cykhash",
     "mmh3",
     "pydantic",
-    "faiss-cpu",
+    # faiss-cpu 1.10+ imports numpy._core and fails with diskannpy's NumPy 1.25 pin.
+    "faiss-cpu==1.9.0.post1",
     "torch"
 ]
 


### PR DESCRIPTION
## Summary
- Pin `faiss-cpu` to `1.9.0.post1` to avoid import failures with NumPy 1.25.
- Keep vector index dependencies compatible with `diskannpy==0.7.0`, which pins `numpy==1.25`.
- Add an inline dependency note explaining why newer FAISS wheels are not currently used.
- 
## Motivation
Linux vector index tests were failing because newer `faiss-cpu` wheels import `numpy._core`, which is unavailable in NumPy 1.25. Since `diskannpy==0.7.0` requires NumPy 1.25, the unconstrained `faiss-cpu` dependency could resolve to an incompatible version and break all vector index tests at import time.

## Test Plan
- [x] Reinstall dependencies in a clean Python 3.11 Linux environment.
- [x] Run `python -m pytest -q tests/integration/indexing/test_vector_index.py --vector_index_test local`.
