### PR TITLE
Store vector index artifacts through MULLER storage

### DIFF
--- a/muller/core/query/inverted_index_vectorized.py
+++ b/muller/core/query/inverted_index_vectorized.py
@@ -23,6 +23,7 @@ import mmh3
 import numpy as np
 
 from muller.constants import FIRST_COMMIT_ID, FILTER_LOG
+from muller.core.storage.cache_utils import get_base_storage
 from muller.util.exceptions import InvertedIndexNotExistsError, InvertedIndexUnsupportedError, \
     InvertedIndexNotFoundError, ExecuteError, UnsupportedMethod
 
@@ -187,21 +188,25 @@ class InvertedIndexVectorized(object):
             num_of_batches = int(num_of_batches)
             num_of_shards = int(num_of_shards)
 
-        # Define a new temporary index folder, then delete the previous temporary folder (if it exists)
-        # to avoid accidental mixing or reuse.
-        tmp_path = os.path.join(self.dataset.path, self.index_folder + "_tmp")
-        if os.path.exists(tmp_path):
-            shutil.rmtree(tmp_path)
+        # Define a new temporary index prefix, then delete leftovers from the
+        # previous attempt. Python indexing stores these artifacts through
+        # MULLER storage; the C++ path still needs a local directory because
+        # the native code writes files by path.
+        use_uuids = bool(uuids)
+        tmp_meta = [num_of_batches, num_of_shards, use_uuids]
+        if use_cpp:
+            tmp_path = os.path.join(self.dataset.path, self.index_folder + "_tmp")
+            if os.path.exists(tmp_path):
+                shutil.rmtree(tmp_path)
 
-        # Create a log file to record the metadata of this indexing run.
-        # Note that this is only for temporary logging purposes!
-        log_path = os.path.join(self.dataset.path, self.index_folder + "_tmp", self.col_log_folder)
-        if not os.path.exists(log_path):
-            use_uuids = bool(uuids)
-            os.makedirs(log_path)
-            tmp_meta = [num_of_batches, num_of_shards, use_uuids]
-            with open(os.path.join(log_path, self.col_log_file), "w") as f:
-                json.dump(tmp_meta, f)
+            log_path = os.path.join(self.dataset.path, self.index_folder + "_tmp", self.col_log_folder)
+            if not os.path.exists(log_path):
+                os.makedirs(log_path)
+                with open(os.path.join(log_path, self.col_log_file), "w") as f:
+                    json.dump(tmp_meta, f)
+        else:
+            self._delete_storage_prefix(self.index_folder + "_tmp")
+            self._save_run_settings(self.index_folder + "_tmp", tmp_meta)
 
         # Read the stopword list and store it in a list.
         if index_type == "fuzzy_match":
@@ -273,13 +278,15 @@ class InvertedIndexVectorized(object):
 
         # If no temporary index file folder has already been generated, raise an error and return immediately.
         tmp_index_path = os.path.join(self.dataset.path, self.index_folder + "_tmp")
-        if not os.path.exists(tmp_index_path):
+        if use_cpp and not os.path.exists(tmp_index_path):
+            raise InvertedIndexNotExistsError(self.column_name)
+        if not use_cpp and not self._storage_prefix_exists(self.index_folder + "_tmp"):
             raise InvertedIndexNotExistsError(self.column_name)
 
         # Formally build the index. Note: A new (column_name)_optimized index folder is created here,
         # and all indexes are written into it.
         optimized_index_path = os.path.join(self.dataset.path, self.index_folder + f"_optimized")
-        if not os.path.exists(optimized_index_path):
+        if use_cpp and not os.path.exists(optimized_index_path):
             # It must be created in the main process. If created in a child process, conflicts will occur!
             os.makedirs(optimized_index_path)
         # During merging, you need to determine whether this is a merge during index creation or during an update:
@@ -314,26 +321,32 @@ class InvertedIndexVectorized(object):
             for res in results:
                 res.get()
 
-        # Rename the original index folder (if it exists) to col_[uuid].
-        # Then, rename the col_optimized folder to col, and delete the col_tmp folder.
-        official_index_path = os.path.join(self.dataset.path, self.index_folder)
-        old_index_path = official_index_path + "_" + uuid.uuid4().hex
-        if os.path.exists(old_index_path):
-            shutil.rmtree(old_index_path)
-        if os.path.exists(official_index_path):
-            os.rename(official_index_path, old_index_path)
-            self.logger.info(f"Rename the old index folder as {old_index_path}")
+        if use_cpp:
+            # Rename the original index folder (if it exists) to col_[uuid].
+            # Then, rename the col_optimized folder to col, and delete the col_tmp folder.
+            official_index_path = os.path.join(self.dataset.path, self.index_folder)
+            old_index_path = official_index_path + "_" + uuid.uuid4().hex
+            if os.path.exists(old_index_path):
+                shutil.rmtree(old_index_path)
+            if os.path.exists(official_index_path):
+                os.rename(official_index_path, old_index_path)
+                self.logger.info(f"Rename the old index folder as {old_index_path}")
 
-        os.rename(official_index_path + f"_optimized", official_index_path)
-        self.logger.info(f"Generate new index folder of {self.column_name} successfully.")
+            os.rename(official_index_path + f"_optimized", official_index_path)
+            self.logger.info(f"Generate new index folder of {self.column_name} successfully.")
 
-        if os.path.exists(tmp_index_path):
-            shutil.rmtree(tmp_index_path)
-            self.logger.info(f"Successfully delete {tmp_index_path} (the unoptimized index).")
+            if os.path.exists(tmp_index_path):
+                shutil.rmtree(tmp_index_path)
+                self.logger.info(f"Successfully delete {tmp_index_path} (the unoptimized index).")
 
-        if delete_old_index and os.path.exists(old_index_path):
-            shutil.rmtree(old_index_path)
-            self.logger.info(f"Successfully delete {old_index_path} (the old index)!")
+            if delete_old_index and os.path.exists(old_index_path):
+                shutil.rmtree(old_index_path)
+                self.logger.info(f"Successfully delete {old_index_path} (the old index)!")
+        else:
+            self._promote_storage_prefix(self.index_folder + "_optimized", self.index_folder)
+            self._delete_storage_prefix(self.index_folder + "_tmp")
+            self._delete_storage_prefix(self.index_folder + "_optimized")
+            self.logger.info(f"Generate new index prefix of {self.column_name} successfully.")
 
 
     def update_index(self,
@@ -391,11 +404,69 @@ class InvertedIndexVectorized(object):
         """Function to check created index's completeness."""
         path = os.path.join(self.dataset.path, folder, self.col_log_folder)
         current_batches = set()
-        for file_name in os.listdir(path):
-            if file_name.find(self.col_log_file) == -1:
-                current_batches.add(int(file_name))
+        if os.path.exists(path):
+            for file_name in os.listdir(path):
+                if file_name.find(self.col_log_file) == -1:
+                    current_batches.add(int(file_name))
+        else:
+            current_batches = set(self._list_completed_batches(folder))
         unfinished_batches = num_of_batches - len(current_batches)
         return unfinished_batches
+
+    def _storage_keys_under(self, prefix: str):
+        prefix = prefix.rstrip("/")
+        prefix_with_slash = f"{prefix}/"
+        keys = set(self.storage._all_keys())
+        try:
+            keys.update(get_base_storage(self.storage)._all_keys(refresh_tag=True))
+        except TypeError:
+            keys.update(get_base_storage(self.storage)._all_keys())
+        except Exception:
+            pass
+        return sorted(
+            key for key in keys
+            if key == prefix or key.startswith(prefix_with_slash)
+        )
+
+    def _storage_prefix_exists(self, prefix: str):
+        return bool(self._storage_keys_under(prefix))
+
+    def _delete_storage_prefix(self, prefix: str):
+        for key in self._storage_keys_under(prefix):
+            del self.storage[key]
+        self.storage.flush()
+
+    def _promote_storage_prefix(self, source_prefix: str, target_prefix: str):
+        self._delete_storage_prefix(target_prefix)
+        source_prefix = source_prefix.rstrip("/")
+        source_prefix_with_slash = f"{source_prefix}/"
+        for source_key in self._storage_keys_under(source_prefix):
+            relative_key = (
+                source_key[len(source_prefix_with_slash):]
+                if source_key.startswith(source_prefix_with_slash)
+                else source_key.rsplit("/", 1)[-1]
+            )
+            self.storage[os.path.join(target_prefix, relative_key)] = self.storage[source_key]
+        self.storage.flush()
+
+    def _run_settings_key(self, folder: str):
+        return os.path.join(folder, self.col_log_folder, self.col_log_file)
+
+    def _save_run_settings(self, folder: str, settings: list):
+        self.storage[self._run_settings_key(folder)] = json.dumps(settings).encode("utf-8")
+        self.storage.flush()
+
+    def _load_run_settings(self, folder: str):
+        return json.loads(self.storage[self._run_settings_key(folder)].decode("utf-8"))
+
+    def _list_completed_batches(self, folder: str):
+        log_prefix = os.path.join(folder, self.col_log_folder)
+        completed_batches = []
+        for key in self._storage_keys_under(log_prefix):
+            file_name = key.rsplit("/", 1)[-1]
+            if file_name.find(self.col_log_file) == -1:
+                completed_batches.append(int(file_name))
+        return completed_batches
 
 
     def reshard_index(self, old_shard_num: int, new_shard_num: int, max_workers: int = 16):
@@ -656,19 +727,15 @@ class InvertedIndexVectorized(object):
 
 
     def _setup_paths(self, batch_params):
-        tmp_path = os.path.join(self.dataset.path, self.index_folder + "_tmp")
-        if os.path.exists(tmp_path):
-            shutil.rmtree(tmp_path)
-
-        log_path = os.path.join(tmp_path, self.col_log_folder)
-        os.makedirs(log_path, exist_ok=True)
-
-        with open(os.path.join(log_path, self.col_log_file), "w") as f:
-            json.dump([
+        self._delete_storage_prefix(self.index_folder + "_tmp")
+        self._save_run_settings(
+            self.index_folder + "_tmp",
+            [
                 batch_params['num_of_batches'],
                 batch_params['num_of_shards'],
                 batch_params['use_uuids']
-            ], f)
+            ],
+        )
 
     def _create_cpp_index(self, batch_params, cut_all, stop_words, compulsory_words, case_sensitive, max_workers):
         """Create cpp index"""
@@ -1032,19 +1099,24 @@ class InvertedIndexVectorized(object):
                       ):
         try:
             # 0. Check whether the target index file already exists in the optimized folder.
-            optimized_index_path = os.path.join(self.dataset.path, self.index_folder + f"_optimized")
-            if os.path.exists(optimized_index_path) and str(shard_id) in os.listdir(optimized_index_path):
+            optimized_index_prefix = self.index_folder + f"_optimized"
+            if self._storage_prefix_exists(os.path.join(optimized_index_prefix, str(shard_id))):
                 self.logger.info(f"Already exists {shard_id}. Skip!")
                 return
 
             merged = defaultdict(set)
             # Note: If there is only a single file from start to finish and the current operation is creating an index,
             # there's no need to read it into memory—just copy it directly to the target location.
-            file_list = os.listdir(os.path.join(self.dataset.path, self.index_folder + "_tmp", str(shard_id)))
-            current_index_folder = os.path.join(self.dataset.path, self.index_folder)
+            tmp_shard_prefix = os.path.join(self.index_folder + "_tmp", str(shard_id))
+            file_list = [
+                key.rsplit("/", 1)[-1]
+                for key in self._storage_keys_under(tmp_shard_prefix)
+            ]
             if len(file_list) == 1 and optimize_mode != "update":
-                shutil.copy(os.path.join(self.dataset.path, self.index_folder + "_tmp", str(shard_id), "0"),
-                            os.path.join(self.dataset.path, self.index_folder + "_optimized", str(shard_id)))
+                self.storage[os.path.join(optimized_index_prefix, str(shard_id))] = self.storage[
+                    os.path.join(tmp_shard_prefix, file_list[0])
+                ]
+                self.storage.flush()
 
             else:
                 # Merge all key-value pairs under the current shard_id folder.
@@ -1055,7 +1127,7 @@ class InvertedIndexVectorized(object):
 
                 # Check if an existing index folder is present;
                 # if so, and the current operation is an index update, merge the corresponding shard_id as well.
-                if os.path.exists(current_index_folder) and optimize_mode == "update":
+                if self._storage_prefix_exists(self.index_folder) and optimize_mode == "update":
                     tmp_dict = pickle.loads(self.storage[os.path.join(self.index_folder,
                                                                       str(shard_id))])
                     for word, pos_set in tmp_dict.items():
@@ -1192,6 +1264,8 @@ class InvertedIndexVectorized(object):
             for file in os.listdir(log_path):
                 if file.find("log") == -1:
                     existing_batches.append(int(file))
+        else:
+            existing_batches = self._list_completed_batches(self.index_folder)
         self.logger.info(f"The following batches are already constructed: {existing_batches}")
         return existing_batches
 
@@ -1215,6 +1289,11 @@ class InvertedIndexVectorized(object):
             if os.path.exists(log_path):
                 with open(log_path, 'r') as f:
                     settings = json.load(f)
+                self.logger.info(f"We did not finish the construction of the original indexes. Now we can continue. "
+                             f"Note that we will use the original number of batches.")
+                self.logger.info(f"Original settings: {settings}")
+            elif self._storage_prefix_exists(self._run_settings_key(self.index_folder)):
+                settings = self._load_run_settings(self.index_folder)
                 self.logger.info(f"We did not finish the construction of the original indexes. Now we can continue. "
                              f"Note that we will use the original number of batches.")
                 self.logger.info(f"Original settings: {settings}")

--- a/muller/core/query/operations/vector_search_ops.py
+++ b/muller/core/query/operations/vector_search_ops.py
@@ -147,11 +147,10 @@ def _get_vector_index(ds):
     except Exception as e:
         raise ModuleNotFoundError("please install dependency for vector search first.") from e
     if ds.vector_index is None:
-        base_path = ds.path
         branch_name = ds.branch
         commit_id = ds.pending_commit_id
         try:
-            ds.vector_index = TensorVectorIndex(parent_path=base_path, branch_name=branch_name)
+            ds.vector_index = TensorVectorIndex(storage=ds.storage, branch_name=branch_name)
         except Exception as e:
             logger.warning(f"the dataset has not been indexed for branch {branch_name} and commit id {commit_id}")
             raise Exception from e

--- a/muller/core/vector/algorithms/faiss_index.py
+++ b/muller/core/vector/algorithms/faiss_index.py
@@ -93,6 +93,16 @@ class FaissVectorIndex:
         raise IndexError(f"index file: {index_file} not found.")
 
     @classmethod
+    def loads(cls, data: bytes, **kwargs) -> faiss.Index:
+        """
+        Load a Faiss index from bytes stored by MULLER storage.
+        """
+        index = faiss.deserialize_index(np.frombuffer(data, dtype=np.uint8))
+        if kwargs.get("device") == "gpu":
+            index = faiss.index_cpu_to_gpu(index)
+        return index
+
+    @classmethod
     def save(cls, index: faiss.Index, **kwargs):
         """
         Default method for saving Faiss vector index.
@@ -103,6 +113,13 @@ class FaissVectorIndex:
         param = IndexParam.SaveFaissIndex.model_validate(kwargs)
         index_file = param.path / f"{param.index_name}.index"
         faiss.write_index(index, str(index_file))
+
+    @classmethod
+    def dumps(cls, index: faiss.Index) -> bytes:
+        """
+        Serialize a Faiss index to bytes for storage providers.
+        """
+        return bytes(faiss.serialize_index(index))
 
     @classmethod
     def _get_faiss_metric(cls, metric: str):

--- a/muller/core/vector/artifact_store.py
+++ b/muller/core/vector/artifact_store.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026 Xueling Lin
+
+import json
+import os
+import posixpath
+from pathlib import Path
+from typing import Dict, List
+
+from muller.core.storage import StorageProvider
+
+
+class IndexArtifactStore:
+    """Small storage-backed helper for vector index artifacts."""
+
+    def __init__(self, storage: StorageProvider, root: str):
+        self.storage = storage
+        self.root = root.strip("/")
+
+    def key(self, *parts: str) -> str:
+        clean_parts = [str(part).strip("/") for part in parts if str(part).strip("/")]
+        if self.root:
+            return posixpath.join(self.root, *clean_parts)
+        return posixpath.join(*clean_parts)
+
+    def exists(self, *parts: str) -> bool:
+        try:
+            self.storage[self.key(*parts)]
+            return True
+        except KeyError:
+            return False
+
+    def read_bytes(self, *parts: str) -> bytes:
+        return self.storage[self.key(*parts)]
+
+    def write_bytes(self, data: bytes, *parts: str) -> None:
+        self.storage[self.key(*parts)] = data
+
+    def load_json(self, *parts: str) -> Dict:
+        return json.loads(self.read_bytes(*parts).decode("utf-8"))
+
+    def save_json(self, data: Dict, *parts: str) -> None:
+        self.write_bytes(
+            json.dumps(data, sort_keys=True).encode("utf-8"),
+            *parts,
+        )
+
+    def list_prefix(self, *parts: str) -> List[str]:
+        prefix = self.key(*parts).rstrip("/")
+        prefix_with_slash = f"{prefix}/"
+        return sorted(
+            key for key in self.storage._all_keys()
+            if key == prefix or key.startswith(prefix_with_slash)
+        )
+
+    def delete_prefix(self, *parts: str) -> None:
+        keys = set(self.list_prefix(*parts))
+        if not keys:
+            return
+        for key in keys:
+            del self.storage[key]
+
+    def publish_dir(self, local_dir: Path, *parts: str) -> List[Dict[str, object]]:
+        manifest = []
+        for root, _, files in os.walk(local_dir):
+            for file_name in files:
+                local_path = Path(root, file_name)
+                relative_path = local_path.relative_to(local_dir).as_posix()
+                artifact_key = self.key(*parts, relative_path)
+                content = local_path.read_bytes()
+                self.storage[artifact_key] = content
+                manifest.append({
+                    "path": relative_path,
+                    "key": artifact_key,
+                    "size": len(content),
+                })
+        manifest.sort(key=lambda item: item["path"])
+        return manifest
+
+    def materialize_dir(self, local_dir: Path, *parts: str) -> None:
+        prefix = self.key(*parts).rstrip("/")
+        prefix_with_slash = f"{prefix}/"
+        for key in self.list_prefix(*parts):
+            relative_path = key[len(prefix_with_slash):] if key.startswith(prefix_with_slash) else Path(key).name
+            local_path = local_dir / relative_path
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            local_path.write_bytes(self.storage[key])

--- a/muller/core/vector/vector_index.py
+++ b/muller/core/vector/vector_index.py
@@ -6,16 +6,18 @@
 #
 # Copyright (c) 2026 Xueling Lin
 
-import json
 import logging
-import shutil
+import tempfile
+import uuid
 from pathlib import Path
 from typing import Dict, Union, List, Tuple, TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
 
+from muller.core.storage import StorageProvider
 from muller.core.tensor import Tensor
+from .artifact_store import IndexArtifactStore
 from . import utils
 from .exceptions import (
     IndexNotFoundError,
@@ -44,7 +46,7 @@ class VectorIndex:
 
     def __init__(
         self,
-        parent_path: Path,
+        artifact_store: IndexArtifactStore,
         tensor_name: str,
         index_name: str,
         device: str = "cpu",
@@ -52,13 +54,14 @@ class VectorIndex:
         self._index = None
         self.index_name: str = index_name
         self.tensor_name: str = tensor_name
-        self.parent_path: Path = parent_path
+        self.artifact_store = artifact_store
         self._device: str = device
         self._meta: Dict = {}
+        self._local_dir: tempfile.TemporaryDirectory[str] | None = None
 
         # preload index meta
-        if self.meta_file.exists() and self.meta_file.is_file():
-            self._meta = json.load(self.meta_file.open(mode="r"))
+        if self.artifact_store.exists(self.meta_key):
+            self._meta = self._load_meta()
 
     @property
     def index(self):
@@ -74,31 +77,31 @@ class VectorIndex:
         return self._index
 
     @property
-    def path(self):
+    def index_prefix(self):
         """
-        The path to save the vector index.
+        The storage prefix for this vector index.
         Returns:
-            A pathlib.Path of the directory that saving the index file.
+            A storage key prefix.
         """
-        return Path(self.parent_path, self.tensor_name, self.index_name)
+        return f"{self.tensor_name}/{self.index_name}"
 
     @property
-    def meta_file(self):
+    def meta_key(self):
         """
-        The meta file to save the metadata.
+        The storage key for metadata.
         Returns:
-            A pathlib.Path of metadata file.
+            A storage key.
         """
-        return self.path / "meta.json"
+        return f"{self.index_prefix}/meta.json"
 
     @property
-    def index_file(self):
+    def artifact_prefix(self):
         """
-        The index file path.
+        The storage prefix for the current index artifact files.
         Returns:
-            A pathlib.Path of index file.
+            A storage key prefix.
         """
-        return self.path / f"{self.index_name}.index"
+        return self._meta.get("artifact_prefix", f"{self.index_prefix}/artifacts")
 
     @property
     def is_exist(self):
@@ -107,7 +110,7 @@ class VectorIndex:
         Returns:
             True if the index exist, otherwise False.
         """
-        return self.path.exists()
+        return self.artifact_store.exists(self.meta_key)
 
     @property
     def is_loaded(self):
@@ -211,6 +214,7 @@ class VectorIndex:
             **param: the create index parameters for specific vector index type.
         """
         logging.info("Start building vector index...")
+        self.artifact_store.storage.check_readonly()
         if len(vector_array.shape) > 2:
             raise CreateIndexError(
                 f"unexpect vector_array format with shape {vector_array.shape}"
@@ -225,7 +229,10 @@ class VectorIndex:
         id_array = np.ascontiguousarray(id_array, dtype=np.int64)
         dimension = vector_array.shape[1]
         index_creator = utils.load_algo(index_type)
-        param.update({"path": str(self.path)})
+        if index_type == "DISKANN":
+            self._reset_local_dir()
+            param.update({"path": str(self.local_path)})
+        old_artifact_prefix = self._meta.get("artifact_prefix")
         self._index, parameter = index_creator.create(
             vector_array=vector_array,
             id_array=id_array,
@@ -233,6 +240,8 @@ class VectorIndex:
             metric=metric,
             **param,
         )
+        parameter = dict(parameter)
+        parameter.pop("path", None)
         self._meta = {
             "index_name": self.index_name,
             "index_type": index_type,
@@ -241,8 +250,7 @@ class VectorIndex:
             "parameter": parameter,
             "commit_id": commit_id,
         }
-        self._save_index(self._index)
-        self._save_meta(self._meta)
+        self._save_index_and_meta(self._index, self._meta, old_artifact_prefix)
         logging.info("Finish building vector index.")
 
     def search(
@@ -274,7 +282,9 @@ class VectorIndex:
         """
         Drop the vector index in disk.
         """
-        shutil.rmtree(self.path)
+        self.artifact_store.storage.check_readonly()
+        self.artifact_store.delete_prefix(self.index_prefix)
+        self.artifact_store.storage.flush()
 
     def add_data(self, input_array: NDArray[np.float32], id_array: NDArray[np.int64]):
         """
@@ -299,30 +309,79 @@ class VectorIndex:
                 f"but index with {self._meta['dimension']}"
             )
 
+    @property
+    def local_path(self) -> Path:
+        if self._local_dir is None:
+            self._reset_local_dir()
+        return Path(self._local_dir.name)
+
+    def _reset_local_dir(self):
+        if self._local_dir is not None:
+            self._local_dir.cleanup()
+        self._local_dir = tempfile.TemporaryDirectory(
+            prefix=f"muller-vector-index-{self.tensor_name}-{self.index_name}-"
+        )
+
     def _load_meta(self):
-        if self.meta_file.exists() and self.meta_file.is_file():
-            return json.loads(self.meta_file.read_text())
-        raise IndexError("index meta file not found.")
+        try:
+            return self.artifact_store.load_json(self.meta_key)
+        except KeyError as err:
+            raise IndexError("index meta file not found.") from err
 
     def _load_index(self, **kwargs):
         index = utils.load_algo(self.index_type)
+        if hasattr(index, "loads"):
+            artifact_name = self._meta.get("artifact", f"{self.index_name}.index")
+            data = self.artifact_store.read_bytes(self.artifact_prefix, artifact_name)
+            kwargs.setdefault("device", self._device)
+            return index.loads(data, **kwargs)
+
+        self._reset_local_dir()
+        self.artifact_store.materialize_dir(self.local_path, self.artifact_prefix)
         kwargs.update(
             {
-                "path": self.path,
+                "path": self.local_path,
                 "index_name": self.index_name,
             }
         )
         return index.load(**kwargs)
 
     def _save_meta(self, vector_index_meta: Dict, overwrite: bool = True):
-        self.path.mkdir(parents=True, exist_ok=overwrite)
-        with self.meta_file.open(mode="w") as meta_file:
-            json.dump(vector_index_meta, meta_file)
+        self.artifact_store.save_json(vector_index_meta, self.meta_key)
+        self.artifact_store.storage.flush()
 
-    def _save_index(self, vector_index):
-        self.path.mkdir(parents=True, exist_ok=True)
+    def _save_index_and_meta(
+        self,
+        vector_index,
+        vector_index_meta: Dict,
+        old_artifact_prefix: str | None = None,
+    ):
         index_algo = utils.load_algo(self.index_type)
-        index_algo.save(index=vector_index, path=self.path, index_name=self.index_name)
+        if old_artifact_prefix is None:
+            old_artifact_prefix = self._meta.get("artifact_prefix")
+        new_artifact_prefix = f"{self.index_prefix}/artifacts-{uuid.uuid4().hex}"
+        manifest = []
+
+        if hasattr(index_algo, "dumps"):
+            artifact_name = f"{self.index_name}.index"
+            data = index_algo.dumps(vector_index)
+            self.artifact_store.write_bytes(data, new_artifact_prefix, artifact_name)
+            manifest.append({
+                "path": artifact_name,
+                "key": self.artifact_store.key(new_artifact_prefix, artifact_name),
+                "size": len(data),
+            })
+            vector_index_meta["artifact"] = artifact_name
+        else:
+            manifest = self.artifact_store.publish_dir(self.local_path, new_artifact_prefix)
+
+        vector_index_meta["artifact_prefix"] = new_artifact_prefix
+        vector_index_meta["manifest"] = manifest
+        self._save_meta(vector_index_meta)
+
+        if old_artifact_prefix and old_artifact_prefix != new_artifact_prefix:
+            self.artifact_store.delete_prefix(old_artifact_prefix)
+            self.artifact_store.storage.flush()
 
 
 class TensorVectorIndex:
@@ -331,8 +390,9 @@ class TensorVectorIndex:
     API.
     """
 
-    def __init__(self, parent_path: Path, branch_name: str):
-        self.path = Path(parent_path, "_vector_index", branch_name)
+    def __init__(self, storage: StorageProvider, branch_name: str):
+        self.storage = storage
+        self.artifact_store = IndexArtifactStore(storage, f"_vector_index/{branch_name}")
         self.branch_name = branch_name
 
         self._index_map: Dict[str, Dict[str, VectorIndex]] = {}
@@ -346,9 +406,7 @@ class TensorVectorIndex:
         Returns:
             List of tensor names which has been created vector index.
         """
-        return [
-            tensor_dir.name for tensor_dir in self.path.iterdir() if tensor_dir.is_dir()
-        ]
+        return sorted(self._index_map.keys())
 
     @staticmethod
     def _uuid_to_id(
@@ -411,7 +469,7 @@ class TensorVectorIndex:
 
         """
         overwrite = create_param.get("overwrite", False)
-        vector_index = VectorIndex(self.path, tensor.key, index_name)
+        vector_index = VectorIndex(self.artifact_store, tensor.key, index_name)
         if overwrite or not vector_index.is_exist:
             vector_array = tensor.numpy()
             vector_index.build_index(
@@ -511,9 +569,6 @@ class TensorVectorIndex:
         # if drop the last index of tensor, remove tensor level directory
         if len(tensor_indexes) == 0:
             self._index_map.pop(tensor.key, None)
-            tensor_path = self.path / tensor.key
-            if tensor_path.exists():
-                tensor_path.rmdir()
 
     def update_index(
         self,
@@ -545,21 +600,28 @@ class TensorVectorIndex:
         uuid_to_pos = {str(uuid): pos for pos, uuid in enumerate(current_uuids)}
         id_array = np.array([uuid_to_pos[str(uuid)] for uuid, _ in added_items], dtype=np.int64)
         vector_index.add_data(data_array, id_array)
-        vector_index.commit_id = new_commit_id
+        vector_index._meta["commit_id"] = new_commit_id
+        vector_index._save_index_and_meta(vector_index.index, vector_index._meta)
 
     def _init_tensor_index(self):
-        if self.path.exists():
-            for tensor_name in self.indexed_tensors:
-                self._index_map[tensor_name] = {}
-                tensor_index_path = Path(self.path, tensor_name)
-                index_name_list = [
-                    index_dir.name
-                    for index_dir in tensor_index_path.iterdir()
-                    if index_dir.is_dir()
-                ]
-                for index_name in index_name_list:
-                    vector_index = VectorIndex(self.path, tensor_name, index_name)
-                    self._index_map[tensor_name][index_name] = vector_index
+        root = self.artifact_store.root.rstrip("/")
+        prefix = f"{root}/" if root else ""
+        for key in self.artifact_store.list_prefix():
+            if not key.endswith("/meta.json"):
+                continue
+            relative_key = key[len(prefix):] if prefix and key.startswith(prefix) else key
+            parts = relative_key.split("/")
+            if len(parts) != 3:
+                continue
+            tensor_name, index_name, meta_file = parts
+            if meta_file != "meta.json":
+                continue
+            self._index_map.setdefault(tensor_name, {})
+            self._index_map[tensor_name][index_name] = VectorIndex(
+                self.artifact_store,
+                tensor_name,
+                index_name,
+            )
 
     def _cache_vector_index(
         self, tensor: Tensor, index_name: str, vector_index: VectorIndex

--- a/tests/integration/indexing/test_inverted_index.py
+++ b/tests/integration/indexing/test_inverted_index.py
@@ -181,6 +181,41 @@ def test_inverted_index(storage):
     assert ds_test_21.filtered_index == [6]
 
 
+def test_vectorized_inverted_index_python_artifacts_use_storage(tmp_path):
+    ds = muller.dataset(path=str(tmp_path / "vectorized_inverted_index"), reset=True)
+    with ds:
+        ds.create_tensor("text", htype="text")
+        ds.text.append("alpha")
+        ds.text.append("beta")
+        ds.text.append("alpha")
+        ds.commit()
+
+    ds.create_index_vectorized(
+        "text",
+        index_type="exact_match",
+        use_cpp=False,
+        num_of_batches=1,
+        num_of_shards=2,
+        max_workers=1,
+        force_create=True,
+    )
+
+    index_keys = sorted(
+        key for key in ds.storage._all_keys()
+        if key.startswith("inverted_index_dir_vec/")
+    )
+    assert "inverted_index_dir_vec/main/meta.json" in index_keys
+    assert "inverted_index_dir_vec/main/text/0" in index_keys
+    assert "inverted_index_dir_vec/main/text/1" in index_keys
+    assert not any("_tmp" in key or "_optimized" in key for key in index_keys)
+
+    filtered = ds.filter_vectorized(
+        [("text", "==", "alpha")],
+        use_local_index=True,
+    )
+    assert filtered.filtered_index == [0, 2]
+
+
 def test_inverted_index_with_multi_user(storage):
     """test inverted index with multi user"""
     values = ["白日依山尽，黄河入海流，欲穷千里目，更上一层楼",

--- a/tests/integration/indexing/test_vector_index.py
+++ b/tests/integration/indexing/test_vector_index.py
@@ -19,6 +19,7 @@ from numpy._typing import NDArray
 
 import muller
 from muller.core.vector.exceptions import SearchError
+from muller.util.exceptions import ReadOnlyModeError
 from tests.constants import SMALL_TEST_PATH
 from tests.utils import official_path, check_skip_vector_index_test
 
@@ -26,6 +27,90 @@ DISKANNPY_AVAILABLE = importlib.util.find_spec("diskannpy") is not None
 DISKANNPY_SKIP = pytest.mark.skipif(
     not DISKANNPY_AVAILABLE, reason="diskannpy is required for DISKANN vector index tests"
 )
+
+
+def _add_storage_backed_vectors(ds):
+    with ds:
+        ds.create_tensor(
+            name="vectors", htype="vector", dtype="float32", dimension=3
+        )
+        vectors = ds.vectors
+        vectors.append(np.array([0.0, 0.0, 0.0], dtype=np.float32))
+        vectors.append(np.array([0.1, 0.1, 0.1], dtype=np.float32))
+        vectors.append(np.array([1.0, 1.0, 1.0], dtype=np.float32))
+        ds.commit()
+
+
+def _vector_index_keys(ds):
+    return sorted(
+        key for key in ds.storage._all_keys()
+        if key.startswith("_vector_index/")
+    )
+
+
+def test_vector_index_artifacts_are_storage_backed_and_reloadable(tmp_path):
+    path = tmp_path / "vector_index_storage"
+    ds = muller.dataset(path=str(path), reset=True)
+    _add_storage_backed_vectors(ds)
+
+    ds.create_vector_index(
+        tensor_name="vectors", index_name="flat", index_type="FLAT", metric="l2"
+    )
+
+    keys = _vector_index_keys(ds)
+    assert "_vector_index/main/vectors/flat/meta.json" in keys
+    assert any(key.endswith("/flat.index") for key in keys)
+
+    meta = ds.vector_index.get_vector_index(ds.vectors, "flat")._meta
+    assert meta["manifest"]
+    assert meta["manifest"][0]["key"] in keys
+
+    reloaded = muller.load(path=str(path))
+    reloaded.load_vector_index(tensor_name="vectors", index_name="flat")
+    dist_list, id_list = reloaded.vector_search(
+        query_vector=np.array([[0.0, 0.0, 0.0]], dtype=np.float32),
+        tensor_name="vectors",
+        index_name="flat",
+        topk=1,
+    )
+    assert id_list.tolist() == [[0]]
+    assert dist_list.tolist() == [[0.0]]
+
+
+def test_vector_index_drop_removes_storage_artifacts(tmp_path):
+    path = tmp_path / "vector_index_drop"
+    ds = muller.dataset(path=str(path), reset=True)
+    _add_storage_backed_vectors(ds)
+
+    ds.create_vector_index(
+        tensor_name="vectors", index_name="flat", index_type="FLAT", metric="l2"
+    )
+    assert _vector_index_keys(ds)
+
+    ds.drop_vector_index(tensor_name="vectors", index_name="flat")
+
+    assert _vector_index_keys(ds) == []
+
+
+def test_vector_index_read_only_blocks_writes(tmp_path):
+    path = tmp_path / "vector_index_read_only"
+    ds = muller.dataset(path=str(path), reset=True)
+    _add_storage_backed_vectors(ds)
+    ds.create_vector_index(
+        tensor_name="vectors", index_name="flat", index_type="FLAT", metric="l2"
+    )
+
+    read_only_ds = muller.load(path=str(path), read_only=True)
+    with pytest.raises(ReadOnlyModeError):
+        read_only_ds.create_vector_index(
+            tensor_name="vectors",
+            index_name="readonly",
+            index_type="FLAT",
+            metric="l2",
+        )
+
+    with pytest.raises(ReadOnlyModeError):
+        read_only_ds.drop_vector_index(tensor_name="vectors", index_name="flat")
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- Add `IndexArtifactStore` to persist vector index metadata and artifacts through the existing `StorageProvider` abstraction.
- Refactor vector index creation, loading, updating, and dropping so storage is the source of truth instead of dataset-local paths.
- Serialize FAISS indexes directly as storage-backed bytes; keep local directories only as temporary adapter workspaces for filesystem-bound backends like DiskANN.
- Move the Python path of vectorized inverted indexing closer to storage-backed temp, log, and optimized prefixes while preserving the existing C++ local-path flow.

## Test Plan

- `python -m compileall muller/core/vector muller/core/query/inverted_index_vectorized.py`
- `python -m compileall tests/integration/indexing/test_vector_index.py tests/integration/indexing/test_inverted_index.py`
- `pytest tests/integration/indexing/test_vector_index.py::test_vector_index_artifacts_are_storage_backed_and_reloadable tests/integration/indexing/test_vector_index.py::test_vector_index_drop_removes_storage_artifacts tests/integration/indexing/test_vector_index.py::test_vector_index_read_only_blocks_writes tests/integration/indexing/test_inverted_index.py::test_vectorized_inverted_index_python_artifacts_use_storage -q`
- Smoke-tested FLAT create/search/unload/load/drop, FLAT incremental update, HNSW reload/search, and Python `create_index_vectorized(..., use_cpp=False)`.