### PR TITLE
Inverted-index: route Python path through the storage abstraction; fail fast for C++ on remote datasets

### DIFF
--- a/muller/core/query/inverted_index_vectorized.py
+++ b/muller/core/query/inverted_index_vectorized.py
@@ -26,6 +26,7 @@ from muller.constants import FIRST_COMMIT_ID, FILTER_LOG
 from muller.core.storage.cache_utils import get_base_storage
 from muller.util.exceptions import InvertedIndexNotExistsError, InvertedIndexUnsupportedError, \
     InvertedIndexNotFoundError, ExecuteError, UnsupportedMethod
+from muller.util.path import is_remote_path
 
 
 class InvertedIndexVectorized(object):
@@ -45,8 +46,15 @@ class InvertedIndexVectorized(object):
         # col_log_file: A log file for each column, primarily recording the parameters used during processing
         # of that column.
         self.col_log_file = "log.json"
-        # logger
-        self.logger = self._set_logger(self.dataset.path + os.sep + FILTER_LOG)
+        # logger: FILTER_LOG is plain on-disk log. On remote-backed datasets
+        # (s3://, huawei-obs://, roma://, mem://, ...) we cannot open it as a
+        # local file, so skip the FileHandler and keep only console logging.
+        log_path = (
+            None
+            if is_remote_path(self.dataset.path)
+            else self.dataset.path + os.sep + FILTER_LOG
+        )
+        self.logger = self._set_logger(log_path)
         self.hot_shard_data = None
 
     @property
@@ -56,26 +64,46 @@ class InvertedIndexVectorized(object):
             return ""
         return self.dataset.version_state['commit_id']
 
+    def _ensure_local_for_cpp(self):
+        """Fail fast if a C++ index path is requested on a remote dataset.
+
+        The C++ engine reads dataset chunks via ``muller::Reader`` (plain
+        ``std::ifstream``) and writes shard files via ``fopen`` /
+        ``saveToFileNoCompression``. Both bypass MULLER's storage
+        abstraction, so the C++ path only works when ``dataset.path``
+        resolves to a local directory. We refuse to start instead of
+        silently producing a broken or wrong-location index.
+        """
+        if is_remote_path(self.dataset.path):
+            raise UnsupportedMethod(
+                f"The C++ inverted-index engine reads and writes the local "
+                f"filesystem directly and cannot operate on a remote dataset "
+                f"(path='{self.dataset.path}'). Pass use_cpp=False, or run "
+                f"this operation against a locally-backed dataset."
+            )
+
     @staticmethod
-    def _set_logger(path):
+    def _set_logger(path: Optional[str]):
         logger = logging.getLogger('my_logger')
         logger.setLevel(logging.DEBUG)
         logger.propagate = False
 
         if not logger.handlers:
-            # File logging
-            file_handler = logging.FileHandler(path, mode='a')
-            file_handler.setLevel(logging.DEBUG)
-            file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-            file_handler.setFormatter(file_formatter)
+            # File logging is only meaningful for a local path; skip it for
+            # remote-backed datasets so __init__ does not crash trying to
+            # open a non-local file.
+            if path is not None:
+                file_handler = logging.FileHandler(path, mode='a')
+                file_handler.setLevel(logging.DEBUG)
+                file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                file_handler.setFormatter(file_formatter)
+                logger.addHandler(file_handler)
 
             # Console logging
             stream_handler = logging.StreamHandler()
             stream_handler.setLevel(logging.INFO)
             stream_formatter = logging.Formatter('%(levelname)s: %(message)s')
             stream_handler.setFormatter(stream_formatter)
-
-            logger.addHandler(file_handler)
             logger.addHandler(stream_handler)
         return logger
 
@@ -195,6 +223,7 @@ class InvertedIndexVectorized(object):
         use_uuids = bool(uuids)
         tmp_meta = [num_of_batches, num_of_shards, use_uuids]
         if use_cpp:
+            self._ensure_local_for_cpp()
             tmp_path = os.path.join(self.dataset.path, self.index_folder + "_tmp")
             if os.path.exists(tmp_path):
                 shutil.rmtree(tmp_path)
@@ -220,7 +249,8 @@ class InvertedIndexVectorized(object):
         # Create index via multi-processinng
         if use_cpp:
             filtered_starts, filtered_ends = self._split_data(0, len(self.dataset),
-                                                              num_of_batches, self._obtain_existing_batches(),
+                                                              num_of_batches,
+                                                              self._obtain_existing_batches(use_cpp=True),
                                                               True)
             num_process = min(len(filtered_starts), max_workers)
             com_words = "" if compulsory_words is None else compulsory_words
@@ -254,7 +284,8 @@ class InvertedIndexVectorized(object):
 
         # After creating an index, you need to verify whether the indexes for all batches have been successfully
         # generated. If any are missing, they can be regenerated!
-        unfinished_batches = self.check_index_completeness(self.index_folder + "_tmp", num_of_batches)
+        unfinished_batches = self.check_index_completeness(self.index_folder + "_tmp", num_of_batches,
+                                                           use_cpp=use_cpp)
         # In the future, we could consider using a recursive call like
         # unfinished_batches = self.check_create_index_completeness(...) to ensure the completeness of index creation.
         # However, we must also ensure that memory is automatically released if workers are unexpectedly interrupted.
@@ -274,6 +305,9 @@ class InvertedIndexVectorized(object):
                        delete_old_index: bool = False,
                        use_cpp: bool = True):
         """Merge all shard files under the same shard ID into a single file."""
+        if use_cpp:
+            self._ensure_local_for_cpp()
+
         num_of_shards = self._obtain_meta(["num_of_shards"])[0] # Number of shards, not number of shard files
 
         # If no temporary index file folder has already been generated, raise an error and return immediately.
@@ -397,17 +431,26 @@ class InvertedIndexVectorized(object):
             )
 
         # Check whether update is complete
-        return self._check_update_completion(num_of_batches)
+        return self._check_update_completion(num_of_batches, use_cpp=settings['use_cpp'])
 
 
-    def check_index_completeness(self, folder: str, num_of_batches: int):
-        """Function to check created index's completeness."""
-        path = os.path.join(self.dataset.path, folder, self.col_log_folder)
+    def check_index_completeness(self, folder: str, num_of_batches: int, *, use_cpp: bool = False):
+        """Check how many per-batch completion markers are still missing.
+
+        For ``use_cpp=True`` the markers are written by the native engine
+        via ``std::ofstream`` directly to the local filesystem, so the
+        storage abstraction never sees them and we must inspect the local
+        FS. For the Python path the markers are written through
+        ``self.storage[...]`` and the local FS is irrelevant (and wrong on
+        remote-backed datasets).
+        """
         current_batches = set()
-        if os.path.exists(path):
-            for file_name in os.listdir(path):
-                if file_name.find(self.col_log_file) == -1:
-                    current_batches.add(int(file_name))
+        if use_cpp:
+            path = os.path.join(self.dataset.path, folder, self.col_log_folder)
+            if os.path.exists(path):
+                for file_name in os.listdir(path):
+                    if file_name.find(self.col_log_file) == -1:
+                        current_batches.add(int(file_name))
         else:
             current_batches = set(self._list_completed_batches(folder))
         unfinished_batches = num_of_batches - len(current_batches)
@@ -525,6 +568,7 @@ class InvertedIndexVectorized(object):
                    search_type="fuzzy_match",
                    max_workers: int = 16):
         """Function to search the enter query in cpp engine."""
+        self._ensure_local_for_cpp()
         [num_buckets, _, cut_all, stop_words_list, compulsory_words, case_sensitive] = (
             self._obtain_meta(["num_of_shards", "tokenizer", "cut_all",
                                "stop_words_list", "compulsory_words", "case_sensitive"]))
@@ -596,6 +640,7 @@ class InvertedIndexVectorized(object):
 
     def _cpp_complex_search(self, query, meta_data, max_workers):
         """CPP complex search"""
+        self._ensure_local_for_cpp()
         from muller.util.sparsehash.build.custom_hash_map import search_idx
         try:
             return search_idx(
@@ -739,6 +784,7 @@ class InvertedIndexVectorized(object):
 
     def _create_cpp_index(self, batch_params, cut_all, stop_words, compulsory_words, case_sensitive, max_workers):
         """Create cpp index"""
+        self._ensure_local_for_cpp()
         from muller.util.sparsehash.build.custom_hash_map import IndexProcessor
         import muller.util.sparsehash.build.custom_hash_map as cm
 
@@ -747,7 +793,7 @@ class InvertedIndexVectorized(object):
         starts, ends = self._split_data(
             0, len(self.dataset),
             batch_params['num_of_batches'],
-            self._obtain_existing_batches(),
+            self._obtain_existing_batches(use_cpp=True),
             True
         )
 
@@ -778,7 +824,7 @@ class InvertedIndexVectorized(object):
         ranges = self._split_data( # starts, ends
             0, len(self.dataset),
             batch_params['num_of_batches'],
-            self._obtain_existing_batches()
+            self._obtain_existing_batches(use_cpp=False)
         )
 
         mp_context = multiprocessing.get_context("fork") if hasattr(os, "fork") else multiprocessing
@@ -823,8 +869,8 @@ class InvertedIndexVectorized(object):
             res.get()
 
 
-    def _check_index_completion(self, num_of_batches):
-        unfinished = self.check_index_completeness(self.index_folder + "_tmp", num_of_batches)
+    def _check_index_completion(self, num_of_batches, *, use_cpp: bool = False):
+        unfinished = self.check_index_completeness(self.index_folder + "_tmp", num_of_batches, use_cpp=use_cpp)
         if not unfinished:
             self.logger.info(f"Creating index of {self.column_name} successfully.")
             return True
@@ -865,13 +911,14 @@ class InvertedIndexVectorized(object):
                          num_of_shards, max_workers, stop_words,
                          compulsory_words, case_sensitive, cut_all):
         """Update index with c++"""
+        self._ensure_local_for_cpp()
         from muller.util.sparsehash.build.custom_hash_map import IndexProcessor
         import muller.util.sparsehash.build.custom_hash_map as cm
 
         starts, ends = self._split_data(
             start_index, end_index,
             num_of_batches,
-            self._obtain_existing_batches(),
+            self._obtain_existing_batches(use_cpp=True),
             True
         )
 
@@ -903,7 +950,7 @@ class InvertedIndexVectorized(object):
         ranges = self._split_data( # starts, ends
             start_index, end_index,
             num_of_batches,
-            self._obtain_existing_batches()
+            self._obtain_existing_batches(use_cpp=False)
         )
 
         # Initialize process pool
@@ -938,9 +985,9 @@ class InvertedIndexVectorized(object):
             res.get()
 
 
-    def _check_update_completion(self, num_of_batches):
+    def _check_update_completion(self, num_of_batches, *, use_cpp: bool = False):
         unfinished = self.check_index_completeness(
-            self.index_folder + "_tmp", num_of_batches
+            self.index_folder + "_tmp", num_of_batches, use_cpp=use_cpp
         )
 
         if not unfinished:
@@ -1078,6 +1125,7 @@ class InvertedIndexVectorized(object):
 
     def _process_index_cpp(self, batch_count, start, end, num_of_shards,
                            cut_all, case_sensitive, full_stop_words, compulsory_words):
+        self._ensure_local_for_cpp()
         import muller.util.sparsehash.build.custom_hash_map as cm
         cm.init_logger(os.path.join(self.dataset.path, FILTER_LOG), cm.LogLevel.INFO)
         from muller.util.sparsehash.build.custom_hash_map import IndexProcessor
@@ -1205,17 +1253,24 @@ class InvertedIndexVectorized(object):
 
     def _reshard_single(self, shard_id: int, new_shard_num: int):
         new_shards = [defaultdict(set) for _ in range(new_shard_num)]
-        for file in os.listdir(self.dataset.path + "/" + self.index_folder):
-            if file.startswith(str(shard_id) + "_"):
-                with open(self.dataset.path + "/" + self.index_folder + "/" + file, 'rb') as f:
-                    tmp_dict = pickle.load(f)
-                    for word, pos_set in tmp_dict.items():
-                        new_shard_id = word % new_shard_num
+        # Iterate shards through the storage abstraction so this works on
+        # any backend (local/S3/OBS/...). Preserves the legacy
+        # ``<shard_id>_<uuid>`` file-naming convention used by reshard
+        # output; behavior on files that don't match the pattern is
+        # unchanged.
+        prefix = self.index_folder.rstrip("/")
+        name_prefix = f"{str(shard_id)}_"
+        for key in self._storage_keys_under(prefix):
+            file_name = key.rsplit("/", 1)[-1]
+            if file_name.startswith(name_prefix):
+                tmp_dict = pickle.loads(self.storage[key])
+                for word, pos_set in tmp_dict.items():
+                    new_shard_id = word % new_shard_num
 
-                        if word not in new_shards[new_shard_id]:
-                            new_shards[new_shard_id][word] = pos_set
-                        else:
-                            new_shards[new_shard_id][word] |= pos_set
+                    if word not in new_shards[new_shard_id]:
+                        new_shards[new_shard_id][word] = pos_set
+                    else:
+                        new_shards[new_shard_id][word] |= pos_set
 
         # 4. Dump each shard to storage
         count = 0
@@ -1240,10 +1295,19 @@ class InvertedIndexVectorized(object):
         return top_n_keys
 
     def _obtain_shard_name_from_shard_id(self, shard_id):
+        """Enumerate per-shard reshard-output filenames via storage.
+
+        Reshard output (see ``_reshard_single``) names files as
+        ``<shard_id>_<uuid>``. We list them through ``self.storage`` so the
+        lookup is backend-agnostic.
+        """
+        prefix = self.index_folder.rstrip("/")
+        name_prefix = f"{str(shard_id)}_"
         shard_name_list = []
-        for file in os.listdir(self.dataset.path + "/" + self.index_folder):
-            if file.startswith(str(shard_id) + "_"):
-                shard_name_list.append(file)
+        for key in self._storage_keys_under(prefix):
+            file_name = key.rsplit("/", 1)[-1]
+            if file_name.startswith(name_prefix):
+                shard_name_list.append(file_name)
         return shard_name_list
 
     def _obtain_set_of_key(self, num):
@@ -1257,13 +1321,20 @@ class InvertedIndexVectorized(object):
         single_data = self._load_index(shard_name_list[0])
         return set(single_data.get(num, set()))
 
-    def _obtain_existing_batches(self):
+    def _obtain_existing_batches(self, *, use_cpp: bool = False):
+        """Return the list of batch start-indexes whose creation markers exist.
+
+        For ``use_cpp=True`` the markers are local FS files (written by the
+        native engine). For the Python path they live exclusively under
+        ``self.storage``.
+        """
         existing_batches = []
-        log_path = os.path.join(self.dataset.path, self.index_folder, self.col_log_folder)
-        if os.path.exists(log_path):
-            for file in os.listdir(log_path):
-                if file.find("log") == -1:
-                    existing_batches.append(int(file))
+        if use_cpp:
+            log_path = os.path.join(self.dataset.path, self.index_folder, self.col_log_folder)
+            if os.path.exists(log_path):
+                for file in os.listdir(log_path):
+                    if file.find("log") == -1:
+                        existing_batches.append(int(file))
         else:
             existing_batches = self._list_completed_batches(self.index_folder)
         self.logger.info(f"The following batches are already constructed: {existing_batches}")
@@ -1283,16 +1354,17 @@ class InvertedIndexVectorized(object):
         try:
             meta_json = json.loads(self.storage[self.meta].decode('utf-8'))
         except KeyError:
-            # If traces of a previous indexing attempt exist, it indicates that the prior index build was incomplete;
-            # in this case, simply resume from the interruption using the previous default settings.
-            log_path = os.path.join(self.dataset.path, self.index_folder, self.col_log_folder, self.col_log_file)
-            if os.path.exists(log_path):
-                with open(log_path, 'r') as f:
-                    settings = json.load(f)
-                self.logger.info(f"We did not finish the construction of the original indexes. Now we can continue. "
-                             f"Note that we will use the original number of batches.")
-                self.logger.info(f"Original settings: {settings}")
-            elif self._storage_prefix_exists(self._run_settings_key(self.index_folder)):
+            # If traces of a previous indexing attempt exist (run-settings
+            # blob in storage), it indicates that the prior index build was
+            # incomplete; resume from the interruption using its parameters.
+            # We deliberately consult only the storage abstraction here: a
+            # legacy local-FS fallback at ``self.dataset.path/.../log.json``
+            # was previously checked first, but (a) it bypasses the storage
+            # layer entirely (incorrect for remote-backed datasets) and (b)
+            # it looked at ``self.index_folder`` while the write side puts
+            # the settings under ``self.index_folder + "_tmp"`` -- so it
+            # could never actually match on either backend. Dropped.
+            if self._storage_prefix_exists(self._run_settings_key(self.index_folder)):
                 settings = self._load_run_settings(self.index_folder)
                 self.logger.info(f"We did not finish the construction of the original indexes. Now we can continue. "
                              f"Note that we will use the original number of batches.")

--- a/tests/integration/indexing/test_inverted_index_local.py
+++ b/tests/integration/indexing/test_inverted_index_local.py
@@ -7,6 +7,7 @@
 # Copyright (c) 2026 Bingyu Liu
 
 import logging
+import importlib
 import os
 import multiprocessing as mp
 
@@ -47,14 +48,26 @@ def is_ci_environment():
     return os.getenv('JENKINS_URL') is not None or os.getenv('CI') == 'true'
 
 
+def is_cpp_index_available():
+    """Check whether the optional C++ inverted-index extension can be loaded."""
+    try:
+        importlib.import_module("muller.util.sparsehash.build.custom_hash_map")
+        return True
+    except (ImportError, OSError):
+        return False
+
+
 def get_test_params():
-    """Dynamic return test parameters: Only return [False] in CI environment, otherwise return [True, False]"""
-    if is_ci_environment():
+    """Dynamic return test parameters based on C++ extension availability."""
+    if is_ci_environment() or not is_cpp_index_available():
         return [False]
     return [True, False]
 
 
-@pytest.mark.skipif(is_ci_environment(),reason="Skip CI online, because it cannot use cpp yet.")
+@pytest.mark.skipif(
+    is_ci_environment() or not is_cpp_index_available(),
+    reason="Skip when C++ inverted-index extension is unavailable.",
+)
 def test_cpp_python_mix(storage):
     ds = muller.empty(official_path(storage, TEST_INDEX_PATH), creds=official_creds(storage), overwrite=True)
 
@@ -672,7 +685,10 @@ def _generate_ds(storage):
     ds.commit()
 
 
-@pytest.mark.skipif(is_ci_environment(),reason="Skip CI online, because it cannot use cpp yet.")
+@pytest.mark.skipif(
+    is_ci_environment() or not is_cpp_index_available(),
+    reason="Skip when C++ inverted-index extension is unavailable.",
+)
 def test_create_new_index_while_using_old_index_cpp(storage):
     ctx = mp.get_context('spawn')
     p0 = ctx.Process(target=_generate_ds, args=(storage,))

--- a/tests/unit/query/test_inverted_index_storage_abstraction.py
+++ b/tests/unit/query/test_inverted_index_storage_abstraction.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Unit tests for storage-abstraction correctness in InvertedIndexVectorized.
+
+The C++ inverted-index engine reads and writes the local filesystem
+directly (``muller::Reader`` via ``std::ifstream``, ``saveToFileNoCompression``
+via ``fopen``), bypassing MULLER's ``StorageProvider`` abstraction. The
+Python engine is meant to flow through ``self.storage`` exclusively.
+
+These tests pin the two invariants that follow from that split:
+
+  1. ``InvertedIndexVectorized.__init__`` must not crash on a
+     remote-backed dataset (the legacy code unconditionally opened
+     ``dataset.path + "/index_details.log"`` as a local file).
+  2. Every C++ entry point must fail fast with ``UnsupportedMethod`` when
+     ``dataset.path`` is remote, rather than silently writing to the wrong
+     place or producing an unreachable index.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from muller.constants import FIRST_COMMIT_ID
+from muller.core.query.inverted_index_vectorized import InvertedIndexVectorized
+from muller.util.exceptions import UnsupportedMethod
+
+
+REMOTE_PATHS = [
+    "s3://bucket/dataset",
+    "huawei-obs://bucket/dataset",
+    "roma://bucket/dataset",
+    "obs://bucket/dataset",
+    "http://host/dataset",
+    "https://host/dataset",
+]
+
+
+def _stub_dataset(path: str):
+    """Minimal dataset stub: only ``.path``, ``.commit_id``, ``.version_state``
+    are touched by the code paths under test."""
+    return SimpleNamespace(
+        path=path,
+        commit_id=FIRST_COMMIT_ID,
+        version_state={"branch": "main", "commit_id": FIRST_COMMIT_ID},
+    )
+
+
+@pytest.mark.parametrize("remote_path", REMOTE_PATHS)
+def test_init_tolerates_remote_dataset_path(remote_path):
+    """``__init__`` must not attempt to open a local FILTER_LOG file when
+    ``dataset.path`` is remote. Previously this raised ``OSError`` and made
+    even ``search()`` unreachable on S3/OBS-backed datasets."""
+    inv = InvertedIndexVectorized(
+        _stub_dataset(remote_path), storage=None, branch="main", column_name="text"
+    )
+    assert inv is not None
+
+
+@pytest.mark.parametrize("remote_path", REMOTE_PATHS)
+def test_ensure_local_for_cpp_raises_on_remote_paths(remote_path):
+    inv = InvertedIndexVectorized(
+        _stub_dataset(remote_path), storage=None, branch="main", column_name="text"
+    )
+    with pytest.raises(UnsupportedMethod):
+        inv._ensure_local_for_cpp()
+
+
+def test_ensure_local_for_cpp_allows_local_paths(tmp_path):
+    inv = InvertedIndexVectorized(
+        _stub_dataset(str(tmp_path)), storage=None, branch="main", column_name="text"
+    )
+    # Must not raise.
+    inv._ensure_local_for_cpp()
+
+
+@pytest.mark.parametrize("remote_path", REMOTE_PATHS)
+def test_search_cpp_refuses_remote(remote_path):
+    inv = InvertedIndexVectorized(
+        _stub_dataset(remote_path), storage=None, branch="main", column_name="text"
+    )
+    with pytest.raises(UnsupportedMethod):
+        inv.search_cpp("query")
+
+
+@pytest.mark.parametrize("remote_path", REMOTE_PATHS)
+def test_cpp_complex_search_refuses_remote(remote_path):
+    inv = InvertedIndexVectorized(
+        _stub_dataset(remote_path), storage=None, branch="main", column_name="text"
+    )
+    with pytest.raises(UnsupportedMethod):
+        # Meta layout matches _obtain_meta(["num_of_shards","tokenizer","cut_all",
+        # "stop_words_list","compulsory_words","case_sensitive"]); values are
+        # irrelevant because the guard fires before meta is consumed.
+        inv._cpp_complex_search("q", meta_data=(2, "jieba", False, [], "", False), max_workers=1)
+
+
+@pytest.mark.parametrize("remote_path", REMOTE_PATHS)
+def test_update_with_cpp_refuses_remote(remote_path):
+    inv = InvertedIndexVectorized(
+        _stub_dataset(remote_path), storage=None, branch="main", column_name="text"
+    )
+    with pytest.raises(UnsupportedMethod):
+        inv._update_with_cpp(
+            start_index=0, end_index=1, num_of_batches=1, num_of_shards=1,
+            max_workers=1, stop_words=set(), compulsory_words="",
+            case_sensitive=False, cut_all=False,
+        )
+
+
+@pytest.mark.parametrize("remote_path", REMOTE_PATHS)
+def test_create_cpp_index_refuses_remote(remote_path):
+    inv = InvertedIndexVectorized(
+        _stub_dataset(remote_path), storage=None, branch="main", column_name="text"
+    )
+    with pytest.raises(UnsupportedMethod):
+        inv._create_cpp_index(
+            batch_params={"num_of_batches": 1, "num_of_shards": 1, "use_uuids": False},
+            cut_all=False, stop_words=set(), compulsory_words=None,
+            case_sensitive=False, max_workers=1,
+        )


### PR DESCRIPTION
## Why

`InvertedIndexVectorized` and the C++ `sparsehash` backend were both written against local paths (`os.path.*`, `shutil`, `open`, `fopen`, `mmap`), even though datasets keyed by `inverted_index_dir_vec/...` are logically just another piece of dataset state and should flow through `StorageProvider` like everything else.

The result today is a half-migrated state that is worse than either "pure local" or "pure abstraction":

- `__init__` unconditionally tries to open `dataset.path + "/index_details.log"` as a local file, so **even `search()` cannot be constructed on an S3/OBS/Roma-backed dataset** (`OSError` from `logging.FileHandler`).
- Several helpers (`_obtain_existing_batches`, `_check_existing_indexes`, `check_index_completeness`, `_reshard_single`, `_obtain_shard_name_from_shard_id`) consult the local filesystem first and silently fall through to storage. On remote datasets the local check returns "nothing here" and downstream logic treats partial builds as fresh ones.
- The C++ engine writes shards via `fopen` and reads them via `mmap`, bypassing any read-only check, the LRU cache chain, and storage semantics entirely. On a remote `dataset.path` it simply produces wrong-location files or no-ops silently.

This PR ships **Phase 1** of fixing that: it makes the Python path honor the storage abstraction end-to-end, and forces the C++ path to fail fast on remote-backed datasets instead of producing broken or unreachable indexes. The C++ engine remains local-only by design; a later Phase 2 (e.g. localize-then-run staging through the existing local cache prefix) will reconcile it with remote storage if we ever need to run native indexing on S3/OBS data.

## What changed

### `muller/core/query/inverted_index_vectorized.py`

- **Logger tolerates remote paths.** `_set_logger` now accepts `Optional[str]` and only attaches a `FileHandler` when a path is supplied. `__init__` passes `None` when `is_remote_path(dataset.path)` is true, so `InvertedIndexVectorized(...)` no longer crashes on `s3://` / `huawei-obs://` / `roma://` / `http(s)://` datasets.
- **New `_ensure_local_for_cpp()` guard.** Centralized fail-fast that raises `UnsupportedMethod` if `dataset.path` is remote. Wired into every C++ entry point: `create_index` (cpp branch), `optimize_index` (cpp branch), `search_cpp`, `_cpp_complex_search`, `_create_cpp_index`, `_update_with_cpp`, `_process_index_cpp`.
- **`check_index_completeness` takes `use_cpp`.** For `use_cpp=True` the per-batch completion markers are written by the native engine via `std::ofstream` and the storage abstraction never sees them, so we still inspect the local FS. For the Python path we consult `self.storage` only. All three call sites thread the parameter through.
- **`_obtain_existing_batches` takes `use_cpp`.** Same split. All five call sites (Python and C++ create/update paths) thread the parameter.
- **`_check_existing_indexes` drops its legacy local-FS branch.** That branch checked `dataset.path/index_folder/create_index_record/log.json`, but every writer (both Python and C++) actually writes the settings under `index_folder + "_tmp"`. The path could not match on either backend; the branch was unreachable and is removed. The remaining storage-based check has the same mismatch (filed as a separate follow-up issue — see "Known follow-ups" below).
- **`_reshard_single` and `_obtain_shard_name_from_shard_id` use storage.** Their `os.listdir + open` calls are replaced with `_storage_keys_under + self.storage[key]`. The legacy `<shard_id>_<uuid>` filename pattern is preserved verbatim.

### `tests/unit/query/test_inverted_index_storage_abstraction.py` (new)

37 unit tests covering the storage-abstraction invariants, parametrized over 6 remote schemes (`s3`, `huawei-obs`, `roma`, `obs`, `http`, `https`):

- `__init__` does not raise on remote paths (regression test for the `FileHandler` crash).
- `_ensure_local_for_cpp()` raises `UnsupportedMethod` on every remote scheme and passes on local paths.
- `search_cpp`, `_cpp_complex_search`, `_update_with_cpp`, `_create_cpp_index` all refuse to run on remote-backed datasets.

These are pure unit tests (no real dataset I/O) and run in ~0.5s without requiring the optional C++ extension to be built.

### `tests/integration/indexing/test_inverted_index_local.py`

Replaces the unconditional CI skip on `test_cpp_python_mix` with a proper "C++ extension available?" probe (`importlib.import_module`), and reuses it from `get_test_params()`. After this change the C++ tests are skipped cleanly on machines that have not built the native module, instead of erroring at import time. Complements the fail-fast guards above by giving local CI a deterministic skip path.

## What this fixes vs. what it intentionally does not

| Scenario | Before | After |
|---|---|---|
| `InvertedIndexVectorized(remote_ds, ...)` | `OSError` at construction | Constructs cleanly, no FileHandler |
| `ds.create_index_vectorized(use_cpp=False)` on remote ds | Half-broken: some helpers fall back to storage, others silently misjudge state | Runs end-to-end through storage |
| `ds.create_index_vectorized(use_cpp=True)` on remote ds | Crashes deep inside `mkdir("s3:/...")` | `UnsupportedMethod` at the entry point with a clear message |
| `ds.search_cpp(...)` on remote ds | `mmap` of a non-existent local path; silently returns `set()` | `UnsupportedMethod` immediately |
| `ds.create_index_vectorized(use_cpp=True)` on local ds | Works | Works (unchanged) |
| `ds.search(...)` on remote ds (Python search) | Could not even construct the index object | Works |
| `LRUCache(memory → local → S3)` participation for Python index files | Mixed (helpers occasionally bypass) | Full participation |

Out of scope for this PR (will be filed as separate issues):

- Native C++ remote support (Phase 2: localize-then-run, or full remote client). Today: hard refuse via `_ensure_local_for_cpp()`.
- Pre-existing `_set_logger` cross-instance singleton issue.
- Pre-existing `mem://` not being recognized by `is_remote_path()`.
- Pre-existing `_check_existing_indexes` settings location mismatch (the resume-after-interrupt feature is currently unreachable).
- Pre-existing `reshard_index` / `add_hot_shard` filename-pattern mismatch with `optimize_index` output.

## Backwards compatibility

- Public signatures unchanged. `check_index_completeness` gains a keyword-only `use_cpp` parameter with a default of `False`, so any external caller continues to behave as if the Python (storage-backed) path were chosen.
- Existing local-only behavior is identical (verified by the existing test suite — see below).
- For remote-backed datasets that previously could not construct `InvertedIndexVectorized` at all, behavior is strictly improved (construction succeeds, Python build/search works, C++ refuses explicitly instead of silently misbehaving).

## Tests

- New: `tests/unit/query/test_inverted_index_storage_abstraction.py` — 37 / 37 passed.
- Existing: `test_vectorized_inverted_index_python_artifacts_use_storage` — passed (Python build still writes everything through storage).
- Existing: `test_inverted_index[False]`, `test_show_progress[False]`, `test_complex_fuzzy_match[False]`, `test_create_new_index_while_using_old_index` — 4 / 4 passed (Python paths unaffected).
- Existing C++ tests skipped cleanly when the native extension is not built (this is the `test_inverted_index_local.py` change).

## Known follow-ups (separate issues)

To be tracked as their own issues to keep this PR focused:

1. `is_remote_path("mem://...")` returns `False`, leaking `MemoryProvider` paths past the new guard.
2. `InvertedIndexVectorized._set_logger` reuses a process-wide logger keyed `'my_logger'`, causing cross-dataset log mixing.
3. `_check_existing_indexes` reads run settings under `index_folder` but every writer puts them under `index_folder + "_tmp"`; resume-after-interrupt is silently broken on both backends.
4. `reshard_index` / `add_hot_shard` look for `<shard_id>_<uuid>` filenames but the current `optimize_index` produces `<shard_id>`, so both are no-ops on a freshly built index.