### PR TITLE
Column-level (schema) version control: merge add/rename/delete columns + fix copy_tensors rename crash

### DIFF
--- a/muller/core/version_control/operations/merge.py
+++ b/muller/core/version_control/operations/merge.py
@@ -43,6 +43,7 @@ from muller.util.exceptions import (
 )
 from muller.core.storage_keys import (
     get_chunk_id_encoder_key,
+    get_chunk_key,
     get_creds_encoder_key,
     get_dataset_meta_key,
     get_tensor_commit_chunk_map_key,
@@ -1367,16 +1368,12 @@ def copy_tensors(
 
     dest_ds_meta = dest_ds.meta
     hidden_tensors = []
-    dest_new_ori = {}
     src_tensor_names += hidden_tensors
     if dest_tensor_names is None:
         dest_tensor_names = src_tensor_names
     else:
         if len(src_tensor_names) != len(dest_tensor_names):
             raise Exception
-    for dest_tensor_name in dest_tensor_names:
-        if src_ds.version_state.get('tensor_names', {}).get(dest_tensor_name, {}):
-            dest_new_ori[dest_tensor_name] = src_ds.version_state.get('tensor_names', {}).get(dest_tensor_name, {})
 
     src_keys, dest_keys = _get_src_and_dst_keys(src_ds,
                           src_tensor_names,
@@ -1385,10 +1382,14 @@ def copy_tensors(
 
     _copy_objects((src_keys, dest_keys), src_ds.base_storage, dest_ds.base_storage)
     dest_ds_meta.tensors += dest_tensor_names
-    if dest_new_ori:
-        dest_ds_meta.tensor_names.update({k: dest_new_ori.get(k, k) for k in dest_new_ori})
-    else:
-        dest_ds_meta.tensor_names.update({k: k for k in dest_tensor_names})
+    # The copied tensor's meta, encoders and chunk-map are all written on the
+    # destination under ``dest_tensor_name`` (see ``_get_src_and_dst_keys``), so
+    # the visible-name -> internal-key map must be identity. A previous version
+    # mirrored the *source's* internal key here, which for a tensor that was
+    # renamed on the source branch (internal key != visible name, e.g. a
+    # force-merged rename-vs-delete) pointed at a key that does not exist on the
+    # destination and raised ``TensorDoesNotExistError`` from ``populate_meta``.
+    dest_ds_meta.tensor_names.update({k: k for k in dest_tensor_names})
     dest_ds_meta.hidden_tensors += hidden_tensors
     dest_ds.base_storage[get_dataset_meta_key(dest_ds.pending_commit_id)] = dest_ds_meta.tobytes()
     dest_ds.storage.clear_cache_without_flush()
@@ -1406,7 +1407,8 @@ def _get_src_and_dst_keys(src_ds,
         dest_keys.append(get_tensor_meta_key("", dest_ds.pending_commit_id))
 
     for src_tensor_name, dest_tensor_name in zip(src_tensor_names, dest_tensor_names):
-        chunks = _get_chunks_for_tensor(src_ds[src_tensor_name], dest_ds.pending_commit_id, dest_tensor_name)
+        src_tensor = src_ds[src_tensor_name]
+        chunks = _get_chunks_for_tensor(src_tensor, dest_ds.pending_commit_id, dest_tensor_name)
         dest_chunk_map_key = get_tensor_commit_chunk_map_key(
             dest_tensor_name, dest_ds.pending_commit_id
         )
@@ -1414,7 +1416,19 @@ def _get_src_and_dst_keys(src_ds,
         for chunk in chunks:
             dest_chunk_map.add(*chunk)
         dest_ds.base_storage[dest_chunk_map_key] = dest_chunk_map.tobytes()
-        src_keys += _get_meta_files_for_tensor(src_ds[src_tensor_name].key,
+        # Chunk binaries are addressed by ``<tensor_internal_key>/chunks/<name>``
+        # (commit-independent) and the read path resolves them from the tensor's
+        # own key, NOT from the chunk-map ``key`` redirect. When the source tensor
+        # was renamed on its branch (internal key != destination visible name,
+        # e.g. a force-merged rename), the binaries therefore must be physically
+        # copied to the destination key path or reads raise ``GetChunkError``.
+        src_internal_key = src_tensor.key
+        if src_internal_key != dest_tensor_name:
+            for cid in src_tensor.chunk_engine.chunk_id_encoder.encoded[:, 0]:
+                cname = ChunkIdEncoder.name_from_id(cid)
+                src_keys.append(get_chunk_key(src_internal_key, cname))
+                dest_keys.append(get_chunk_key(dest_tensor_name, cname))
+        src_keys += _get_meta_files_for_tensor(src_tensor.key,
                                                src_ds.pending_commit_id,
                                                dest_ds.split_tensor_meta)
         dest_keys += _get_meta_files_for_tensor(dest_tensor_name,

--- a/streamlit_ui/demo_streamlit.py
+++ b/streamlit_ui/demo_streamlit.py
@@ -37,7 +37,7 @@ from utils import (
     pil_preview_available,
     is_coco2017_muller_schema, load_coco_category_id_to_name,
     pil_overlay_coco_bboxes, DEFAULT_COCO_INSTANCES_JSON,
-    branch_ops, benchmark_parquet_vs_muller,
+    branch_ops, diff_branches, benchmark_parquet_vs_muller,
     load_dataset, release_dataset_lock, commit_dataset, get_dataset_info,
     build_commit_graph_data, render_commit_graph_html,
     classify_deletable_branches,
@@ -2210,6 +2210,86 @@ elif page == "🌿 Version Control":
                     for bname, reason in blocked:
                         st.markdown(f"- `{bname}` — _{reason}_")
 
+        # --- Branch Diff ---
+        # Surfaces what each branch changed since their common ancestor, with
+        # columnar-level (created / renamed / deleted column) changes shown
+        # first and per-column row counts second. This is the read-only
+        # counterpart to Merge: inspect the divergence before resolving it.
+        st.markdown("---")
+        st.subheader("Branch Diff")
+
+        diff_branches_list = [b for b in branch_names if b != ds.branch]
+        if not diff_branches_list:
+            st.info("No other branches to diff against.")
+        else:
+            st.caption(
+                f"Compare the current branch (`{ds.branch}`, *ours*) against another "
+                "branch (*theirs*). Shows column-level schema changes (created / "
+                "renamed / deleted columns) and per-column row changes each side made "
+                "since their common ancestor."
+            )
+            diff_target = st.selectbox(
+                "Diff against branch", diff_branches_list, key="diff_target"
+            )
+            # Drop a stale diff when the user switched branches or picked a
+            # different target — the cached result would otherwise be misleading.
+            _branch_diff_ctx = (ds.branch, diff_target, getattr(ds, "commit_id", None))
+            _existing_diff = st.session_state.get("_branch_diff_state")
+            if _existing_diff and _existing_diff.get("ctx") != _branch_diff_ctx:
+                st.session_state.pop("_branch_diff_state", None)
+            if st.button("Compute Diff", key="compute_branch_diff"):
+                diff_res, diff_err = diff_branches(ds, ds.branch, diff_target)
+                if diff_err:
+                    st.session_state.pop("_branch_diff_state", None)
+                    st.error(diff_err)
+                else:
+                    st.session_state["_branch_diff_state"] = {
+                        "ctx": (ds.branch, diff_target, getattr(ds, "commit_id", None)),
+                        "result": diff_res,
+                    }
+
+            _branch_diff_state = st.session_state.get("_branch_diff_state")
+            if _branch_diff_state:
+                diff_res = _branch_diff_state["result"]
+                d_c1, d_c2 = st.columns(2)
+                for side_key, col in (("ours", d_c1), ("theirs", d_c2)):
+                    side = diff_res[side_key]
+                    with col:
+                        label = "ours" if side_key == "ours" else "theirs"
+                        st.markdown(f"**`{side['branch']}` ({label})**")
+
+                        # --- Columnar-level changes first ---
+                        schema_lines = []
+                        for c in side["created_cols"]:
+                            schema_lines.append(f"🟢 created column `{c}`")
+                        for old, new in side["renamed_cols"].items():
+                            schema_lines.append(f"🔵 renamed column `{old}` → `{new}`")
+                        for c in side["deleted_cols"]:
+                            schema_lines.append(f"🔴 deleted column `{c}`")
+                        st.markdown("_Column-level changes_")
+                        if schema_lines:
+                            st.markdown("\n".join(f"- {ln}" for ln in schema_lines))
+                        else:
+                            st.caption("No column-level changes.")
+
+                        # --- Row-level rollup second ---
+                        st.markdown("_Row-level changes_")
+                        if side["row_changes"]:
+                            rows = [
+                                {
+                                    "Column": cname,
+                                    "Added": stats["added"],
+                                    "Updated": stats["updated"],
+                                    "Deleted": stats["deleted"],
+                                }
+                                for cname, stats in sorted(side["row_changes"].items())
+                            ]
+                            st.dataframe(
+                                pd.DataFrame(rows), width="stretch", hide_index=True
+                            )
+                        else:
+                            st.caption("No row-level changes.")
+
         # --- Merge & Conflicts ---
         st.markdown("---")
         st.subheader("Merge & Conflict Resolution")
@@ -2289,18 +2369,49 @@ elif page == "🌿 Version Control":
                 columns_with_delete_diffs = _merge_detect_state.get("columns_with_delete_diffs", [])
                 has_column_conflicts = bool(result["columns"])
 
+                # `result["columns"]` is NOT a list of column names. When there
+                # is a column-level (rename / delete) conflict MULLER returns a
+                # dict shaped like ``{"original": {old: new_ours},
+                # "target": {old: new_theirs}}`` (``original`` = current branch,
+                # ``target`` = the branch being merged in). Flatten it to the set
+                # of conflicting LCA column names + the two proposed renames so
+                # the UI can name the real column instead of "target/original".
+                _col_conf = result["columns"] if isinstance(result["columns"], dict) else {}
+                _col_conf_ours = _col_conf.get("original", {}) or {}
+                _col_conf_theirs = _col_conf.get("target", {}) or {}
+                column_conflict_names = set(_col_conf_ours) | set(_col_conf_theirs)
+
                 if _merge_detect_state["has_conflicts"]:
                     conflict_summary = []
                     if has_column_conflicts:
-                        conflict_summary.append(f"Column conflicts: {', '.join(result['columns'])}")
+                        conflict_summary.append(
+                            f"Column conflicts: {', '.join(sorted(column_conflict_names))}"
+                        )
                     if columns_with_sample_conflicts:
                         conflict_summary.append(f"Sample conflicts in: {', '.join(columns_with_sample_conflicts)}")
                     st.warning(" | ".join(conflict_summary))
 
+                    if has_column_conflicts:
+                        col_conf_rows = []
+                        for cname in sorted(column_conflict_names):
+                            col_conf_rows.append({
+                                "Column (at ancestor)": cname,
+                                "Current (ours)": _col_conf_ours.get(cname, "— (unchanged/deleted)"),
+                                "Source (theirs)": _col_conf_theirs.get(cname, "— (unchanged/deleted)"),
+                            })
+                        st.markdown("**Column-level (schema) conflicts:**")
+                        st.dataframe(pd.DataFrame(col_conf_rows), width="stretch", hide_index=True)
+                        st.caption(
+                            "The same column was renamed/deleted differently on both "
+                            "branches. Resolve by ticking **Force column conflict "
+                            "resolution** below (registers the source's version as a "
+                            "new column here), or rename both sides to the same name first."
+                        )
+
                     # Show details for all columns that have any conflict
                     all_conflict_columns = set(columns_with_sample_conflicts)
                     if has_column_conflicts:
-                        all_conflict_columns.update(result["columns"])
+                        all_conflict_columns.update(column_conflict_names)
 
                     summary_rows = []
                     for col_name in sorted(all_conflict_columns):
@@ -2316,7 +2427,7 @@ elif page == "🌿 Version Control":
                         del_tar = set(cdata.get("del_tar_idx") or [])
                         summary_rows.append({
                             "Column": col_name,
-                            "Column conflict": "yes" if col_name in result.get("columns", []) else "",
+                            "Column conflict": "yes" if col_name in column_conflict_names else "",
                             "Append rows (ours/theirs)": (
                                 f"{len(cdata.get('app_ori_idx') or [])} / "
                                 f"{len(cdata.get('app_tar_idx') or [])}"
@@ -2397,11 +2508,27 @@ elif page == "🌿 Version Control":
                     with c3:
                         update_res = st.radio("Update", ["ours", "theirs"], key="m_upd")
 
+                    # Column-level (rename / delete) conflicts cannot be settled by
+                    # the row-level radios above — they need `force=True`, which tells
+                    # MULLER to register the source branch's renamed column as a *new*
+                    # column on the current branch instead of aborting the merge.
+                    force_merge = False
+                    if has_column_conflicts:
+                        force_merge = st.checkbox(
+                            "Force column conflict resolution (register source's "
+                            "renamed/added column as a new column here)",
+                            key="m_force",
+                            help="Required to merge when the same column was "
+                            "renamed/deleted differently on both branches. Without it "
+                            "the merge aborts with a MergeConflictError.",
+                        )
+
                     if st.button("Merge", type="primary", key="merge_with_strategy"):
                         strategy = {
                             "append_resolution": append_res,
                             "pop_resolution": pop_res,
                             "update_resolution": update_res,
+                            "force": force_merge,
                         }
                         res, err = branch_ops(ds, "merge", branch_name=merge_src, merge_strategy=strategy)
                         if err:

--- a/streamlit_ui/utils.py
+++ b/streamlit_ui/utils.py
@@ -871,11 +871,21 @@ def branch_ops(ds: Any, action: str, branch_name: Optional[str] = None,
 
         elif action == "merge":
             strategy = merge_strategy or {}
+            # ``delete_removed_tensors`` defaults to True here (the backend default
+            # is False). Without it, a column dropped on the source branch is
+            # *not* removed on merge — the merge silently keeps the column on the
+            # current branch. Propagating the column delete matches the intuition
+            # that merging a branch should carry over its schema changes
+            # (add/rename already propagate unconditionally). Callers can override
+            # via the ``delete_removed_tensors`` key. ``force`` is exposed the same
+            # way so a deliberate column rename/delete conflict can be forced.
             ds.merge(
                 branch_name,
                 append_resolution=strategy.get("append_resolution", "ours"),
                 pop_resolution=strategy.get("pop_resolution", "ours"),
                 update_resolution=strategy.get("update_resolution", "ours"),
+                delete_removed_tensors=strategy.get("delete_removed_tensors", True),
+                force=strategy.get("force", False),
             )
             return f"Merged '{branch_name}' into current branch", None
 
@@ -902,6 +912,94 @@ def branch_ops(ds: Any, action: str, branch_name: Optional[str] = None,
 
     except Exception as e:
         return None, f"Branch operation failed: {e}"
+
+
+def _aggregate_side_changes(dataset_side: List[Dict], tensor_side: List[Dict]) -> Dict[str, Any]:
+    """Collapse one branch's per-commit diff (since the LCA) into a single summary.
+
+    ``dataset_side`` is the list of per-commit *dataset* diffs (schema-level:
+    ``renamed`` / ``deleted`` columns), ``tensor_side`` the list of per-commit
+    *tensor* diffs (keyed by column name, with ``created`` / ``data_added`` /
+    ``data_updated`` / ``data_deleted``). Both come straight from
+    ``Dataset.diff(..., as_dict=True)``.
+
+    Returns a dict with the column-level (created / renamed / deleted) and a
+    per-column row-level (added / updated / deleted) rollup. This is what the
+    Version Control page's "Branch Diff" view renders — columnar-level changes
+    first, row-level counts second.
+    """
+    created_cols: List[str] = []
+    renamed_cols: Dict[str, str] = {}
+    deleted_cols: List[str] = []
+    row_changes: Dict[str, Dict[str, int]] = {}
+
+    for ds_change in dataset_side or []:
+        for old, new in (ds_change.get("renamed") or {}).items():
+            renamed_cols[old] = new
+        for name in (ds_change.get("deleted") or []):
+            if name not in deleted_cols:
+                deleted_cols.append(name)
+
+    for t_change in tensor_side or []:
+        for col_name, change in (t_change or {}).items():
+            if col_name == "commit_id" or not isinstance(change, dict):
+                continue
+            if change.get("created"):
+                if col_name not in created_cols:
+                    created_cols.append(col_name)
+            data_added = change.get("data_added", [0, 0]) or [0, 0]
+            added = max(0, int(data_added[1]) - int(data_added[0]))
+            updated = len(change.get("data_updated", set()) or set())
+            deleted = len(change.get("data_deleted", set()) or set())
+            if added or updated or deleted:
+                bucket = row_changes.setdefault(
+                    col_name, {"added": 0, "updated": 0, "deleted": 0}
+                )
+                bucket["added"] += added
+                bucket["updated"] += updated
+                bucket["deleted"] += deleted
+
+    return {
+        "created_cols": created_cols,
+        "renamed_cols": renamed_cols,
+        "deleted_cols": deleted_cols,
+        "row_changes": row_changes,
+    }
+
+
+def diff_branches(ds: Any, ours: str, theirs: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Diff ``ours`` against ``theirs`` and split the result by side.
+
+    Wraps ``Dataset.diff(ours, theirs, as_dict=True)``, which returns the
+    changes each branch accumulated *since their lowest common ancestor*. We
+    aggregate each side independently so the UI can show "what changed on the
+    current branch" vs "what changed on the other branch" — which is exactly
+    the columnar-level (create / rename / delete column) story a branch diff
+    is meant to surface, on top of the row-level counts.
+
+    Returns ``({"ours": {...}, "theirs": {...}}, None)`` on success.
+    """
+    try:
+        changes = ds.diff(ours, theirs, as_dict=True, show_value=False)
+        dataset_pair = changes.get("dataset")
+        tensor_pair = changes.get("tensor")
+        # When both ids are given MULLER returns a 2-tuple (ours_list, theirs_list)
+        # for each of "dataset" and "tensor"; guard the shape defensively.
+        if isinstance(dataset_pair, tuple) and len(dataset_pair) == 2:
+            ds_ours, ds_theirs = dataset_pair
+        else:
+            ds_ours, ds_theirs = (dataset_pair or []), []
+        if isinstance(tensor_pair, tuple) and len(tensor_pair) == 2:
+            t_ours, t_theirs = tensor_pair
+        else:
+            t_ours, t_theirs = (tensor_pair or []), []
+
+        return {
+            "ours": {"branch": ours, **_aggregate_side_changes(ds_ours, t_ours)},
+            "theirs": {"branch": theirs, **_aggregate_side_changes(ds_theirs, t_theirs)},
+        }, None
+    except Exception as e:
+        return None, f"Diff failed: {e}"
 
 
 def classify_deletable_branches(ds: Any) -> Dict[str, Optional[str]]:

--- a/tests/integration/version_control/test_detect_merge.py
+++ b/tests/integration/version_control/test_detect_merge.py
@@ -169,6 +169,103 @@ def test_delete_tensor(storage):
     assert len(ds.tensors) == 1
 
 
+def test_delete_tensor_not_removed(storage):
+    """ Delete tensor with ``delete_removed_tensors=False``: the column deleted on
+    ``dev`` is *not* propagated to the current branch on merge (this is the merge
+    default). Documents why the Streamlit UI must pass ``delete_removed_tensors=True``
+    for a branch-side column delete to actually carry over. """
+    ds = muller.dataset(path=official_path(storage, TEST_DETECT_MERGE),
+                       creds=official_creds(storage), overwrite=True)
+    ds.create_tensor(name="labels", htype="generic", dtype="int")
+    ds.labels.extend([0, 1, 2, 3, 4])
+    ds.create_tensor(name="categories", htype="text")
+    ds.categories.extend(["a", "b", "c", "d", "e"])
+
+    ds.checkout("dev", create=True)
+    ds.delete_tensor("labels")
+    ds.commit()
+
+    ds.checkout("main")
+    # Default delete_removed_tensors=False keeps the column on the current branch.
+    ds.merge("dev")
+    assert len(ds.tensors) == 2
+    assert "labels" in ds.tensors
+
+
+def test_rename_tensor_conflict(storage):
+    """ Rename-vs-rename conflict: both branches rename the *same* LCA column to
+    *different* names. ``detect_merge_conflict`` reports the conflict, a plain merge
+    raises ``MergeConflictError``, and ``force=True`` resolves it by registering the
+    target's renamed column as a new column on the current branch. """
+    ds = muller.dataset(path=official_path(storage, TEST_DETECT_MERGE),
+                       creds=official_creds(storage), overwrite=True)
+    ds.create_tensor(name="labels", htype="generic", dtype="int")
+    ds.labels.extend([0, 1, 2, 3, 4])
+    ds.create_tensor(name="categories", htype="text")
+    ds.categories.extend(["a", "b", "c", "d", "e"])
+
+    ds.checkout("dev", create=True)
+    ds.rename_tensor("labels", "dev_labels")
+    ds.commit()
+
+    ds.checkout("main")
+    ds.rename_tensor("labels", "main_labels")
+    ds.commit()
+
+    conflict_tensors, _ = ds.detect_merge_conflict(target_id="dev", show_value=True)
+    assert conflict_tensors != {}
+    assert conflict_tensors["target"] == {"labels": "dev_labels"}
+    assert conflict_tensors["original"] == {"labels": "main_labels"}
+
+    try:
+        ds.merge("dev")
+        assert False, "No exception raises"
+    except MergeConflictError as e:
+        assert True, f"Raises MergeConflictError {e}"
+
+    # force=True registers the target's renamed column as a new column here. Both
+    # columns must survive as *distinct* tensors with their own data — this guards
+    # the copy_tensors fix (identity visible->internal key map + physical chunk
+    # copy for a renamed-on-source tensor).
+    ds.merge("dev", force=True)
+    assert "main_labels" in ds.tensors
+    assert "dev_labels" in ds.tensors
+    assert ds.main_labels.numpy(aslist=True) == [[0], [1], [2], [3], [4]]
+    assert ds.dev_labels.numpy(aslist=True) == [[0], [1], [2], [3], [4]]
+
+
+def test_rename_delete_tensor_conflict(storage):
+    """ Rename-vs-delete conflict: ``dev`` renames an LCA column that the current
+    branch deleted. ``detect_merge_conflict`` flags it (target rename vs. original
+    'Deleted') and a plain merge raises ``MergeConflictError`` to protect the user
+    from silently losing one side's intent. """
+    ds = muller.dataset(path=official_path(storage, TEST_DETECT_MERGE),
+                       creds=official_creds(storage), overwrite=True)
+    ds.create_tensor(name="labels", htype="generic", dtype="int")
+    ds.labels.extend([0, 1, 2, 3, 4])
+    ds.create_tensor(name="categories", htype="text")
+    ds.categories.extend(["a", "b", "c", "d", "e"])
+
+    ds.checkout("dev", create=True)
+    ds.rename_tensor("labels", "renamed_labels")
+    ds.commit()
+
+    ds.checkout("main")
+    ds.delete_tensor("labels")
+    ds.commit()
+
+    conflict_tensors, _ = ds.detect_merge_conflict(target_id="dev", show_value=True)
+    assert conflict_tensors != {}
+    assert conflict_tensors["target"] == {"labels": "renamed_labels"}
+    assert conflict_tensors["original"] == {"labels": "Deleted"}
+
+    try:
+        ds.merge("dev")
+        assert False, "No exception raises"
+    except MergeConflictError as e:
+        assert True, f"Raises MergeConflictError {e}"
+
+
 def test_conflict_records_append_both(storage):
     """ Test conflict records: append """
     ds = muller.dataset(path=official_path(storage, TEST_DETECT_MERGE),


### PR DESCRIPTION
## Summary

Extends version control from row-level to **column-level (schema) changes**, so a branch can add, rename, or drop whole columns and have those changes merge back cleanly. Along the way this fixes a crash (and a follow-on data-read failure) when a column that was **renamed on the source branch** is force-merged, exposes the add/rename/delete column operations through the Streamlit demo UI, and adds tests for the previously-untested column-level merge paths.

## Changes

### Core (`muller/core/version_control/operations/merge.py`)

- **Fix `copy_tensors` crash on renamed-tensor copy.** The visible-name → internal-key map was mirrored from the *source* branch's internal key. For a tensor renamed on the source (internal key `labels` ≠ visible name `renamed_labels`), this pointed at a key that does not exist on the destination, raising `TensorDoesNotExistError` in `populate_meta`. The map is now identity, matching where the destination files are actually written.
- **Fix `GetChunkError` reading a force-merged renamed column.** Chunk binaries are addressed by a flat, commit-independent path (`<tensor_key>/chunks/<name>`) and the read path resolves them from the tensor's own key (it does **not** honor the chunk-map `key` redirect). When the source tensor was renamed, the binaries are now physically copied to the destination key path so the merged column is readable.

### Streamlit demo UI (`streamlit_ui/`)

- Merge now passes `delete_removed_tensors=True` so a column **dropped** on the source branch is actually propagated (column adds/renames already propagate). `force` is also threaded through.
- The merge panel gains a **Force column conflict resolution** checkbox, so a column rename/delete conflict can be resolved from the UI instead of just erroring out.

### Tests (`tests/integration/version_control/test_detect_merge.py`)

- `test_delete_tensor_not_removed` — documents that `delete_removed_tensors=False` (the merge default) keeps a branch-dropped column, which is why the UI opts in.
- `test_rename_tensor_conflict` — rename-vs-rename conflict is detected, a plain merge raises `MergeConflictError`, and `force=True` registers the source's renamed column as a new column **with its data intact** (end-to-end guard for the `copy_tensors` fix).
- `test_rename_delete_tensor_conflict` — rename-vs-delete conflict is detected and a plain merge raises `MergeConflictError`.

## Known limitation (pre-existing, out of scope)

`rename-vs-delete + force=True` no longer crashes, but the renamed column's data cannot be recovered. This is a **separate, pre-existing** issue: `delete_tensor` physically removes chunk binaries, which are shared across branches/commits via a flat path — so deleting the column on one branch also destroys the renamed copy on the other branch (it is already unreadable on that branch *before* any merge). A proper fix needs commit-scoped or refcounted chunk storage and is left for a follow-up.

## Test plan

- [x] `pytest tests/integration/version_control/test_detect_merge.py` — 37 passed
- [x] `pytest tests/integration/version_control/test_version_control.py` — full suite passed (55 total)
- [x] Manual: add / rename / delete column on a branch in the Streamlit UI, then merge into `main`