### PR TITLE
Add CLIP image/text vector search to the multi-user demo (pre-baked embeddings + multi-index UI)

### DIFF
--- a/streamlit_ui/clip_embedding.py
+++ b/streamlit_ui/clip_embedding.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: MPL-2.0
+"""
+CLIP image/text embedding helper for the MULLER vector-search demo.
+
+Single source of truth shared by:
+  * the Streamlit UI (query-by-image / query-by-text in the Vector Search tab),
+  * ``sigmod_demo_revision/vector_search/embed_column.py`` (populate / backfill
+    the ``clip_embedding`` column).
+
+Why CLIP ViT-B/32 (openai/clip-vit-base-patch32, 512-d): see
+``sigmod_demo_revision/vector_search/ANALYSIS.md`` §3 — image->image P@10≈0.70
+(a conservative lower bound; many "misses" are mislabeled images) and near
+perfect text->image, all from a single joint embedding space so one 512-d
+column serves both modalities. Radford et al., ICML 2021, arXiv:2103.00020.
+
+Design notes
+------------
+* Lazy, cached model load (first call pays the cost; later calls reuse).
+* Offline by default: if the CLIP weights are already cached (standard
+  ``~/.cache/huggingface``, or wherever ``HF_HOME`` points), sets
+  HF_HUB_OFFLINE so a sandboxed / air-gapped run never tries the network.
+* Device defaults to **cpu** — on this machine MPS + the torch×MKL OpenMP
+  collision segfaults during batched inference (documented in ANALYSIS.md).
+  Override with env ``MULLER_CLIP_DEVICE=mps`` if your box is happy with it.
+* Embeddings are L2-normalized float32, so a FAISS ``l2``/``ip`` index gives
+  cosine-equivalent ranking.
+"""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Sequence, Union
+
+import numpy as np
+
+MODEL_NAME = "openai/clip-vit-base-patch32"
+EMBED_DIM = 512
+
+ImageLike = Union[str, Path, "np.ndarray", "object"]  # path | array | PIL.Image
+
+
+def _hub_dir() -> Path:
+    """Resolve the HuggingFace hub cache dir (honors HF_HOME, else default)."""
+    hf_home = os.environ.get("HF_HOME")
+    base = Path(hf_home) if hf_home else (Path.home() / ".cache" / "huggingface")
+    return base / "hub"
+
+
+def _configure_env() -> None:
+    """Defuse the torch×MKL/faiss OpenMP duplicate-runtime abort and, when the
+    CLIP weights are already cached, force offline so we never hit the network.
+    Idempotent / non-destructive: never overrides values the caller already set,
+    and never forces a custom cache path (uses HF's standard
+    ``~/.cache/huggingface`` unless the caller set ``HF_HOME``)."""
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+    # torch and faiss each ship their own OpenMP runtime; on this machine
+    # loading both and running multi-threaded segfaults. Pinning to a single
+    # OMP thread (set BEFORE torch/faiss initialize their pools) avoids it and
+    # costs little at demo scale (~60 img/s CLIP on CPU). Override if your box
+    # is happy multi-threaded.
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    os.environ.setdefault("MKL_NUM_THREADS", "1")
+    # If the CLIP weights are visibly cached, stay offline (no network needed).
+    model_cache = _hub_dir() / ("models--" + MODEL_NAME.replace("/", "--"))
+    if model_cache.is_dir():
+        os.environ.setdefault("HF_HUB_OFFLINE", "1")
+        os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+
+def get_device() -> str:
+    forced = os.environ.get("MULLER_CLIP_DEVICE")
+    if forced:
+        return forced
+    return "cpu"  # safe default; see module docstring
+
+
+@lru_cache(maxsize=1)
+def _load():
+    """Load (model, processor, device) once and cache."""
+    _configure_env()
+    import torch
+    from transformers import CLIPModel, CLIPProcessor
+
+    device = get_device()
+    model = CLIPModel.from_pretrained(MODEL_NAME).to(device).eval()
+    proc = CLIPProcessor.from_pretrained(MODEL_NAME)
+    return model, proc, device
+
+
+def _to_pil_list(images: Sequence[ImageLike]):
+    from PIL import Image
+
+    out = []
+    for im in images:
+        if isinstance(im, (str, Path)):
+            out.append(Image.open(im).convert("RGB"))
+        elif isinstance(im, np.ndarray):
+            arr = im
+            if arr.dtype != np.uint8:
+                arr = arr.astype(np.uint8, copy=False)
+            if arr.ndim == 2:
+                out.append(Image.fromarray(arr, mode="L").convert("RGB"))
+            elif arr.ndim == 3 and arr.shape[-1] == 4:
+                out.append(Image.fromarray(arr, mode="RGBA").convert("RGB"))
+            elif arr.ndim == 3 and arr.shape[-1] == 1:
+                out.append(Image.fromarray(arr[..., 0], mode="L").convert("RGB"))
+            else:
+                out.append(Image.fromarray(arr).convert("RGB"))
+        else:  # assume PIL.Image
+            out.append(im.convert("RGB"))
+    return out
+
+
+def _as_feature_tensor(out):
+    import torch
+    if torch.is_tensor(out):
+        return out
+    for attr in ("image_embeds", "text_embeds", "pooler_output", "last_hidden_state"):
+        v = getattr(out, attr, None)
+        if v is not None:
+            return v
+    if isinstance(out, (tuple, list)):
+        return out[0]
+    raise TypeError(f"Cannot extract feature tensor from {type(out)}")
+
+
+def encode_images(images: Sequence[ImageLike], batch_size: int = 32) -> np.ndarray:
+    """Return an (N, 512) float32 L2-normalized array of CLIP image embeddings.
+
+    ``images`` may mix file paths, HxWx3 uint8 numpy arrays, and PIL images.
+    """
+    import torch
+
+    model, proc, device = _load()
+    vecs: List[np.ndarray] = []
+    with torch.no_grad():
+        for i in range(0, len(images), batch_size):
+            pil = _to_pil_list(list(images[i:i + batch_size]))
+            inputs = proc(images=pil, return_tensors="pt").to(device)
+            feats = _as_feature_tensor(model.get_image_features(**inputs))
+            feats = torch.nn.functional.normalize(feats, dim=-1)
+            vecs.append(feats.cpu().numpy().astype(np.float32))
+    if not vecs:
+        return np.zeros((0, EMBED_DIM), dtype=np.float32)
+    return np.ascontiguousarray(np.concatenate(vecs, axis=0), dtype=np.float32)
+
+
+def encode_texts(texts: Sequence[str]) -> np.ndarray:
+    """Return an (N, 512) float32 L2-normalized array of CLIP text embeddings.
+
+    Same vector space as ``encode_images`` -> enables text->image search.
+    """
+    import torch
+
+    model, proc, device = _load()
+    with torch.no_grad():
+        inputs = proc(text=list(texts), return_tensors="pt", padding=True).to(device)
+        feats = _as_feature_tensor(model.get_text_features(**inputs))
+        feats = torch.nn.functional.normalize(feats, dim=-1)
+    return np.ascontiguousarray(feats.cpu().numpy().astype(np.float32), dtype=np.float32)
+
+
+def install_to_numpy_thread_shim() -> None:
+    """Swap MULLER's ProcessPoolExecutor-based full-tensor read for a thread
+    pool.
+
+    ``Tensor.numpy()`` (used by ``create_vector_index`` and by bulk image
+    reads) fans out over chunks with ``ProcessPoolExecutor`` under the default
+    ``strategy="processed"``. ``spawn`` re-imports ``__main__`` (which under
+    ``streamlit run`` is the Streamlit CLI, not our script) and POSIX-semaphore
+    limits can be unavailable in sandboxes — either way it dies. Threads share
+    the address space and are plenty for demo-scale data. Idempotent.
+    """
+    try:
+        import concurrent.futures as _cf
+        import muller.core.chunk.operations.to_numpy as _tonumpy
+    except Exception:
+        return
+    if getattr(_tonumpy, "_muller_ui_thread_shim", False):
+        return
+    _tonumpy.ProcessPoolExecutor = _cf.ThreadPoolExecutor
+    _tonumpy._muller_ui_thread_shim = True

--- a/streamlit_ui/demo_streamlit.py
+++ b/streamlit_ui/demo_streamlit.py
@@ -43,12 +43,25 @@ from utils import (
     classify_deletable_branches,
     list_vector_tensor_names, list_vector_indexes, parse_query_vector,
     run_vector_search, ensure_vector_index, tensor_embedding_dim,
+    vector_index_meta,
     save_query_view, list_saved_views, load_saved_view, delete_saved_view,
     get_view_entry, current_user, set_current_user,
 )
 import streamlit.components.v1 as components
 import pandas as pd
 import numpy as np
+
+# CLIP image/text query support for the Vector Search tab. Configure the
+# embedding env (OMP single-thread, offline HF cache) and install MULLER's
+# thread-pool shim for full-tensor reads BEFORE torch/faiss initialize their
+# OpenMP runtimes — otherwise mixing them segfaults. Importing the module is
+# cheap (no torch yet); the model is loaded lazily on first image/text query.
+try:
+    import clip_embedding as _clip_embedding
+    _clip_embedding._configure_env()
+    _clip_embedding.install_to_numpy_thread_shim()
+except Exception:
+    pass
 
 # ---------------------------------------------------------------------------
 # Page config
@@ -1765,15 +1778,29 @@ elif page == "🔍 Query & Search":
                         "Embedding tensor", selectable, key="qs_vec_tensor"
                     )
                 indexes_for_tensor = idx_map.get(v_tensor, [])
+                _NEW_IDX = "➕ Build new index…"
                 with col_i:
                     if indexes_for_tensor:
-                        v_index = st.selectbox(
-                            "Vector index", indexes_for_tensor, key="qs_vec_index"
+                        _choice = st.selectbox(
+                            "Vector index", indexes_for_tensor + [_NEW_IDX],
+                            key="qs_vec_index",
+                            help="Reuse an existing index, or pick "
+                            f"'{_NEW_IDX}' to build another with a different "
+                            "type/metric.",
                         )
+                        building_new = (_choice == _NEW_IDX)
+                        if building_new:
+                            v_index = st.text_input(
+                                "New index name", value="clip_hnsw",
+                                key="qs_vec_index_new2",
+                            )
+                        else:
+                            v_index = _choice
                     else:
+                        building_new = True
                         v_index = st.text_input(
                             "Vector index (will be created)",
-                            value="demo_flat",
+                            value="clip_flat",
                             key="qs_vec_index_new",
                             help="No existing index on this tensor; one will be "
                             "built on the current commit when you run the search.",
@@ -1785,34 +1812,116 @@ elif page == "🔍 Query & Search":
                     )
 
                 dim = tensor_embedding_dim(ds, v_tensor)
-                qv_help = (
-                    f"Comma/space-separated floats. Expected dimension: {dim}"
-                    if dim else "Comma/space-separated floats."
-                )
-                qv_text = st.text_area(
-                    "Query vector", key="qs_vec_text", height=100, help=qv_help,
-                    placeholder="e.g. 0.12, -0.03, 0.88, ..." if not dim else
-                    ", ".join(["0.0"] * min(int(dim), 8)) + (", ..." if dim and dim > 8 else ""),
-                )
 
-                col_metric, col_type = st.columns(2)
-                with col_metric:
-                    metric = st.selectbox("Metric", ["l2", "cosine", "ip"], key="qs_vec_metric",
-                                          disabled=bool(indexes_for_tensor),
-                                          help="Ignored when reusing an existing index "
-                                          "(that index was built with its own metric).")
-                with col_type:
-                    index_type = st.selectbox("Index type", ["FLAT", "IVF", "IVFPQ"],
-                                              key="qs_vec_idx_type",
-                                              disabled=bool(indexes_for_tensor),
-                                              help="Used only when creating a new index.")
+                # Query input mode. "Image"/"Text" encode the query with CLIP
+                # (openai/clip-vit-base-patch32, 512-d, joint image/text space)
+                # so the demo can run "find images similar to THIS image" and
+                # the cross-modal "find images matching THIS sentence" — both
+                # only make sense against a 512-d CLIP embedding column.
+                qmode = st.radio(
+                    "Query by", ["Vector", "Image", "Text"], horizontal=True,
+                    key="qs_vec_qmode",
+                    help="Image/Text are CLIP-encoded to a 512-d vector. Use "
+                    "them only with a CLIP `clip_embedding` column (build it "
+                    "with embed_column.py).",
+                )
+                qv_text, qv_image, qv_phrase = "", None, ""
+                if qmode == "Vector":
+                    qv_help = (
+                        f"Comma/space-separated floats. Expected dimension: {dim}"
+                        if dim else "Comma/space-separated floats."
+                    )
+                    qv_text = st.text_area(
+                        "Query vector", key="qs_vec_text", height=100, help=qv_help,
+                        placeholder="e.g. 0.12, -0.03, 0.88, ..." if not dim else
+                        ", ".join(["0.0"] * min(int(dim), 8)) + (", ..." if dim and dim > 8 else ""),
+                    )
+                elif qmode == "Image":
+                    qv_image = st.file_uploader(
+                        "Query image", type=["jpg", "jpeg", "png", "bmp", "webp"],
+                        key="qs_vec_image",
+                        help="Upload an image; CLIP encodes it to a 512-d vector.",
+                    )
+                    if qv_image is not None:
+                        st.image(qv_image, width=180, caption="query image")
+                else:  # Text
+                    qv_phrase = st.text_input(
+                        "Query text", key="qs_vec_phrase",
+                        placeholder="e.g. a photo of a dog on the beach",
+                        help="CLIP encodes this sentence into the same space as "
+                        "the image embeddings (text→image search).",
+                    )
+
+                # Metric / index type are independent: ANY type works with ANY
+                # metric (l2 / cosine / ip). When building a NEW index both are
+                # editable; when REUSING an existing one its params are fixed at
+                # build time, so we show the index's real stored values (read
+                # from meta.json) instead of leaving stale, disabled selectboxes
+                # that would misleadingly keep showing the last-built params.
+                if building_new:
+                    col_metric, col_type = st.columns(2)
+                    with col_metric:
+                        metric = st.selectbox(
+                            "Metric (new index)", ["l2", "cosine", "ip"],
+                            key="qs_vec_metric",
+                            help="Distance metric for the new index — independent "
+                            "of the index type. CLIP vectors are L2-normalized, so "
+                            "l2 / cosine / ip rank identically.")
+                    with col_type:
+                        index_type = st.selectbox(
+                            "Index type (new index)", ["FLAT", "HNSWFLAT", "IVFPQ"],
+                            key="qs_vec_idx_type",
+                            help="FAISS backends: FLAT = exact brute force; "
+                            "HNSWFLAT = graph ANN (fast, near-exact); IVFPQ = "
+                            "compressed ANN (approximate/lossy). (DISKANN also "
+                            "exists but needs the diskannpy extra.)")
+                else:
+                    _imeta = vector_index_meta(ds, v_tensor, v_index)
+                    metric = _imeta.get("metric") or "l2"
+                    index_type = _imeta.get("index_type") or "FLAT"
+                    st.caption(
+                        f"Reusing **`{v_index}`** — index type **{index_type}**, "
+                        f"metric **{metric}** (fixed when the index was built; not "
+                        f"editable for an existing index). Pick **➕ Build new "
+                        f"index…** above to try a different type/metric."
+                    )
 
                 if st.button("Run Vector Search", type="primary", key="qs_run_vec"):
-                    qvec, perr = parse_query_vector(qv_text, expected_dim=dim)
+                    qvec, perr = None, None
+                    if qmode == "Vector":
+                        qvec, perr = parse_query_vector(qv_text, expected_dim=dim)
+                    elif qmode == "Image":
+                        if qv_image is None:
+                            perr = "Upload a query image first."
+                        else:
+                            try:
+                                import clip_embedding as _ce
+                                from PIL import Image as _PILImage
+                                _img = _PILImage.open(qv_image).convert("RGB")
+                                with st.spinner("CLIP-encoding query image…"):
+                                    qvec = _ce.encode_images([np.asarray(_img)])[0]
+                            except Exception as _e:
+                                perr = f"CLIP image encoding failed: {_e}"
+                    else:  # Text
+                        if not (qv_phrase or "").strip():
+                            perr = "Enter a query sentence first."
+                        else:
+                            try:
+                                import clip_embedding as _ce
+                                with st.spinner("CLIP-encoding query text…"):
+                                    qvec = _ce.encode_texts([qv_phrase.strip()])[0]
+                            except Exception as _e:
+                                perr = f"CLIP text encoding failed: {_e}"
+                    if perr is None and qvec is not None and dim and len(qvec) != int(dim):
+                        perr = (
+                            f"Query vector dim {len(qvec)} ≠ embedding column dim "
+                            f"{int(dim)}. Image/Text query needs a 512-d CLIP "
+                            f"`clip_embedding` column."
+                        )
                     if perr:
                         st.error(perr)
                     else:
-                        if not indexes_for_tensor:
+                        if v_index and v_index not in indexes_for_tensor:
                             with st.spinner(
                                 f"Building vector index '{v_index}' on '{v_tensor}'…"
                             ):

--- a/streamlit_ui/utils.py
+++ b/streamlit_ui/utils.py
@@ -1680,6 +1680,31 @@ def list_vector_indexes(ds: Any) -> Dict[str, List[str]]:
     return out
 
 
+def vector_index_meta(ds: Any, tensor_name: str, index_name: str) -> Dict[str, Any]:
+    """Read a built vector index's stored params (``index_type``, ``metric``,
+    ``dimension``) from its ``meta.json``.
+
+    Layout mirrors ``list_vector_indexes``:
+        <ds.path>/_vector_index/<branch>/<tensor_name>/<index_name>/meta.json
+
+    Returns an empty dict if the meta cannot be read. These params are fixed at
+    build time, so this is how the UI shows the truth for a *reused* index
+    (rather than whatever the disabled selectboxes happen to display)."""
+    try:
+        mp = (Path(ds.path) / "_vector_index" / ds.branch / tensor_name
+              / index_name / "meta.json")
+        if mp.exists():
+            m = json.loads(mp.read_text(encoding="utf-8"))
+            return {
+                "index_type": m.get("index_type"),
+                "metric": m.get("metric"),
+                "dimension": m.get("dimension"),
+            }
+    except Exception:
+        pass
+    return {}
+
+
 def parse_query_vector(text: str, expected_dim: Optional[int] = None) -> Tuple[Optional[np.ndarray], Optional[str]]:
     """Parse comma/space/newline-separated floats into a 1-D float32 vector.
 


### PR DESCRIPTION
## Summary

Adds end-to-end **content-based (vector) search** to the MULLER multi-user Streamlit demo, built on MULLER's existing `embedding` htype + FAISS vector index. You can now find images by **uploading an example image** or by **typing a sentence** (cross-modal), using CLIP (`openai/clip-vit-base-patch32`, 512-d).

Embeddings are **pre-baked into the demo data** so the dataset natively carries a `clip_embedding` column on import — no live "add column" step. The Vector Search UI is reworked so you can build and compare multiple index types/metrics.

## What's new

**Demo data carries embeddings out of the box**

- `coco_schema.json`: new `clip_embedding` tensor (`htype=embedding`, `float32`).
- `prepare_demo_csvs.py`: computes a CLIP vector per image at export time and writes a `clip_embedding` JSON column into all three CSV shards (toggle via `SHARDS_TO_EMBED`). Batch CSV import already maps `embedding` columns through `json`, so the column lands in the dataset on import.

**Streamlit Vector Search UI (`streamlit_ui/demo_streamlit.py`)**

- New shared encoder module `streamlit_ui/clip_embedding.py` (lazy CLIP load, offline HF cache detection, OpenMP single-thread pin, `to_numpy` thread-pool shim) — used by the UI and by the prep/tooling scripts.
- Query by **Image** (upload), **Text** (sentence), or raw **Vector**.
- **Build new index** even when one already exists; choose **index type** (`FLAT` / `HNSWFLAT` / `IVFPQ`) and **metric** (`l2` / `cosine` / `ip`) — metric and type are independent.
- When reusing an existing index, the UI now shows that index's **real stored params** (read from `meta.json` via new `utils.vector_index_meta`) instead of stale, disabled selectboxes.


## Notable fixes / gotchas handled

- Use `clip_embedding` as the column name (`embedding` is a reserved dataset attribute).
- Rebuild indexes via drop-then-create to avoid the upstream `create_vector_index(overwrite=True)` double-kwarg `TypeError`.
- Pin OpenMP to a single thread so torch and FAISS coexist (otherwise the duplicate-runtime load segfaults on macOS).
- Corrected the index-type options (`IVF` was an invalid value; added `HNSWFLAT`).

## Test plan

- [x] `_selftest_embed.py` — image→image, text→image, and backfill + incremental index update on a tiny real-image dataset.
- [x] `_selftest_csv_embed.py` — a pre-baked `clip_embedding` CSV column round-trips through `add_data_from_csv` into the embedding tensor and is searchable.
- [x] Verified FLAT (l2/cosine), HNSWFLAT (cosine), and IVFPQ (cosine) all build and search at demo scale.
- [x] Manual UI pass: §1 create + import (10-tensor schema) → Vector Search by image and by text; build a new HNSWFLAT/IVFPQ index and compare.

## Notes / limitations

- Requires `transformers` in the `muller` env and CLIP weights cached at `~/.cache/huggingface` (run `prefetch_models.py` once if missing).
- CLIP embeddings are L2-normalized, so `l2` / `cosine` / `ip` rank identically; `IVFPQ` is intentionally lossy (approximate). `DISKANN` is supported by MULLER but omitted from the UI (needs the `diskannpy` extra).
- Default inference device is CPU; set `MULLER_CLIP_DEVICE=mps` to opt in.