### PR TITLE
docs: document create_index_vectorized C++ engine and parallelism tuning; align advanced-query skill

### DIFF
--- a/.claude/skills/muller-advanced-query/SKILL.md
+++ b/.claude/skills/muller-advanced-query/SKILL.md
@@ -38,7 +38,7 @@ Use this skill when the user wants to:
 Handles advanced query and indexing operations.
 
 **Operations:**
-- `create-index` - Create inverted index for text search
+- `create-index` - Create vectorized inverted index for text search (supports the C++ engine)
 - `create-vector-index` - Create vector index (FLAT, HNSW, DISKANN)
 - `load-vector-index` - Load vector index into memory
 - `vector-search` - Perform vector similarity search
@@ -47,9 +47,18 @@ Handles advanced query and indexing operations.
 
 **Usage:**
 ```bash
-# Create inverted index for text search
+# Create vectorized inverted index for text search (Python engine, defaults)
 python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py create-index \
   --path ./my_dataset --tensors "description,title"
+
+# Use the native C++ engine (local datasets only, fuzzy_match only)
+python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py create-index \
+  --path ./my_dataset --tensors "description" --use-cpp
+
+# Parallelize build/search on a large dataset
+python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py create-index \
+  --path ./my_dataset --tensors "description" --use-cpp \
+  --num-of-batches 16 --num-of-shards 16 --max-workers 16
 
 # Create vector index
 python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py create-vector-index \
@@ -66,6 +75,41 @@ python3 .claude/skills/muller-advanced-query/scripts/advanced_query.py aggregate
   --path ./my_dataset --group-by categories --select labels,categories \
   --aggregate-tensors "*"
 ```
+
+## Inverted Index Options (`create-index`)
+
+`create-index` builds a **vectorized** inverted index via `ds.create_index_vectorized()`.
+The dataset must be committed first. Options:
+
+- `--tensors` (required): comma-separated columns; each is indexed separately.
+- `--index-type`: `fuzzy_match` (default, tokenized full-text) or `exact_match`
+  (whole-value match). `exact_match` is **not** supported together with `--use-cpp`.
+- `--use-cpp`: use the native C++ engine. **Local datasets only**, **`fuzzy_match` only**,
+  and requires the compiled extension (built during a standard `pip install .`; unavailable
+  if installed with `BUILD_CPP=false`). Significantly faster than the Python engine.
+- `--force-create`: rebuild from scratch instead of appending to an existing index.
+
+**Choosing the parallelism options** — `--max-workers` is only an upper bound; the real
+parallelism is capped by how many work units exist:
+
+| Option | Governs | Effective parallelism | Default |
+|---|---|---|---|
+| `--num-of-batches` | Build (index creation) | `min(num_of_batches, max_workers)` | `1` |
+| `--num-of-shards` | Search & optimize + storage layout | `min(num_of_shards, max_workers)` | `1` |
+| `--max-workers` | Cap on the above | — | `16` |
+
+- `--num-of-batches` splits the row range into independent build tasks. Because the default
+  is `1`, **raising `--max-workers` alone does not parallelize the build** — increase
+  `--num-of-batches` first.
+- `--num-of-shards` hash-partitions the index and is **fixed at creation time** (change it
+  later only via the Python API `ds.reshard_index()`). More shards means more query-time
+  parallelism and smaller per-shard files.
+- Rules of thumb: small datasets → keep defaults; large datasets → set `--num-of-batches`
+  to roughly `--max-workers` and `--max-workers` near the CPU core count; high query
+  concurrency / large vocabulary → raise `--num-of-shards`.
+
+See the [Indexing API reference](https://the-ai-framework-and-data-tech-lab-hk.github.io/MULLER/api/dataset-query/#dscreate_index_vectorized)
+for full details.
 
 ## Quick Reference
 

--- a/.claude/skills/muller-advanced-query/scripts/advanced_query.py
+++ b/.claude/skills/muller-advanced-query/scripts/advanced_query.py
@@ -30,21 +30,53 @@ except ImportError:
 
 
 def create_index(args):
-    """Create inverted index for text search."""
+    """Create a vectorized inverted index for text search."""
     try:
         ds = muller.load(args.path)
 
         tensors = args.tensors.split(",") if args.tensors else None
-        ds.create_index(tensors)
+        if not tensors:
+            return {
+                "success": False,
+                "operation": "create_index",
+                "error": "ValueError",
+                "message": "At least one tensor (column) is required.",
+                "suggestion": "Pass a comma-separated list, e.g. --tensors description,title"
+            }
+
+        # Only forward tuning options when explicitly set so the library
+        # defaults (num_of_shards=1, num_of_batches=1, max_workers=16) are kept.
+        kwargs = {}
+        if args.num_of_shards is not None:
+            kwargs["num_of_shards"] = args.num_of_shards
+        if args.num_of_batches is not None:
+            kwargs["num_of_batches"] = args.num_of_batches
+        if args.max_workers is not None:
+            kwargs["max_workers"] = args.max_workers
+
+        # create_index_vectorized indexes a single column, so loop over the list.
+        for tensor in tensors:
+            ds.create_index_vectorized(
+                tensor,
+                index_type=args.index_type,
+                use_cpp=args.use_cpp,
+                force_create=args.force_create,
+                **kwargs
+            )
 
         return {
             "success": True,
             "operation": "create_index",
             "result": {
                 "path": args.path,
-                "tensors": tensors
+                "tensors": tensors,
+                "index_type": args.index_type,
+                "use_cpp": args.use_cpp,
+                "num_of_shards": kwargs.get("num_of_shards", 1),
+                "num_of_batches": kwargs.get("num_of_batches", 1),
+                "max_workers": kwargs.get("max_workers", 16)
             },
-            "message": f"Created inverted index for {len(tensors) if tensors else 'all'} tensors"
+            "message": f"Created vectorized inverted index for {len(tensors)} tensor(s)"
         }
     except Exception as e:
         return {
@@ -52,7 +84,9 @@ def create_index(args):
             "operation": "create_index",
             "error": type(e).__name__,
             "message": str(e),
-            "suggestion": "Ensure dataset is committed before creating index"
+            "suggestion": ("Commit the dataset before creating an index. "
+                           "For --use-cpp the dataset must be local and "
+                           "--index-type must be 'fuzzy_match'.")
         }
 
 
@@ -284,9 +318,24 @@ def main():
     subparsers = parser.add_subparsers(dest="command", help="Command to execute")
 
     # Create index command
-    create_index_parser = subparsers.add_parser("create-index", help="Create inverted index")
+    create_index_parser = subparsers.add_parser("create-index", help="Create vectorized inverted index")
     create_index_parser.add_argument("--path", required=True, help="Dataset path")
-    create_index_parser.add_argument("--tensors", help="Comma-separated tensor names")
+    create_index_parser.add_argument("--tensors", required=True, help="Comma-separated tensor (column) names")
+    create_index_parser.add_argument("--index-type", default="fuzzy_match",
+                                     help="fuzzy_match (default) or exact_match "
+                                          "(exact_match is not supported with --use-cpp)")
+    create_index_parser.add_argument("--use-cpp", action="store_true",
+                                     help="Use the native C++ engine (local datasets only, "
+                                          "fuzzy_match only; requires the compiled extension)")
+    create_index_parser.add_argument("--num-of-shards", type=int,
+                                     help="Number of index shards = search-time parallelism, "
+                                          "fixed at creation (default 1)")
+    create_index_parser.add_argument("--num-of-batches", type=int,
+                                     help="Number of build batches = build-time parallelism (default 1)")
+    create_index_parser.add_argument("--max-workers", type=int,
+                                     help="Cap on parallel workers for build/optimize/search (default 16)")
+    create_index_parser.add_argument("--force-create", action="store_true",
+                                     help="Rebuild from scratch instead of appending to an existing index")
 
     # Create vector index command
     create_vector_index_parser = subparsers.add_parser("create-vector-index", help="Create vector index")

--- a/README.md
+++ b/README.md
@@ -225,6 +225,16 @@ ds.commit()
 ds.create_index_vectorized("description")
 res = ds.filter_vectorized([("description", "CONTAINS", "cat")])
 
+# Faster indexing with the native C++ engine (local datasets only, fuzzy_match only)
+ds.create_index_vectorized("description", use_cpp=True)
+
+# Parallelize the build/search on large datasets:
+#   num_of_batches -> build parallelism, num_of_shards -> search parallelism,
+#   max_workers    -> caps both (set near your CPU core count)
+ds.create_index_vectorized(
+    "description", use_cpp=True, num_of_batches=16, num_of_shards=16, max_workers=16
+)
+
 # Comparison and complex queries
 res_1 = ds.filter_vectorized([("labels", ">", 1)])
 res_2 = ds.filter_vectorized([("description", "LIKE", "ca[t]")])
@@ -250,6 +260,14 @@ ds_vec.load_vector_index("embeddings", index_name="hnsw")
 query = np.random.rand(100, 32)
 distances, indices = ds_vec.vector_search(query_vector=query, tensor_name="embeddings", index_name="hnsw", topk=10)
 ```
+
+> **Tuning `create_index_vectorized()`:** `num_of_batches` controls build-time parallelism,
+> `num_of_shards` controls search-time parallelism (and is fixed at creation), and `max_workers`
+> simply caps both — so raising `max_workers` alone does nothing if `num_of_batches`/`num_of_shards`
+> stay at their default of `1`. The C++ engine (`use_cpp=True`) requires the compiled extension,
+> works on local datasets only, and supports `fuzzy_match` indexes only. See the
+> [Indexing API reference](https://the-ai-framework-and-data-tech-lab-hk.github.io/MULLER/api/dataset-query/#dscreate_index_vectorized)
+> for full parameter details and selection guidance.
 
 ### Version Control
 

--- a/docs/api/dataset-query.md
+++ b/docs/api/dataset-query.md
@@ -262,17 +262,120 @@ filtered = ds.filter_vectorized("labels == 5")  # Much faster with index
 
 #### Overview
 
-Create an index optimized for vectorized operations. This is useful for large-scale filtering.
+Create a **vectorized inverted index** on a tensor column to power fast full-text
+(`CONTAINS` / `LIKE`) and exact-match queries through `ds.filter_vectorized()` and
+`ds.query()`. The index is built in parallel and automatically optimized (shard files
+are merged) at the end of creation, so you do **not** need to call `ds.optimize_index()`
+separately after a successful build.
+
+If an index already exists for the column, calling this method again updates it in an
+**append-only** manner (only the newly added rows are indexed) unless you pass
+`force_create=True` to rebuild from scratch.
+
+> **Note:** The dataset must be committed (no uncommitted head changes) before building an
+> index; otherwise the call warns and does nothing.
 
 #### Parameters
 
-- **tensor_name** (`str`): Name of the tensor to index.
-- **num_workers** (`int`, optional): Number of workers for parallel index creation. Defaults to `0`.
-- **scheduler** (`str`, optional): Scheduler type. Defaults to `"threaded"`.
+- **tensor_column** (`str`): Name of the tensor column to index.
+- **index_type** (`str`, optional): `"fuzzy_match"` (tokenized full-text search, the
+  default) or `"exact_match"` (whole-value match). `"exact_match"` is **not** supported
+  together with `use_cpp=True`.
+- **use_uuid** (`bool`, optional): Index by the row UUIDs instead of positional indices.
+  Defaults to `False`.
+- **force_create** (`bool`, optional): If `True`, delete any existing index and rebuild it
+  from scratch instead of appending. Defaults to `False`.
+- **delete_old_index** (`bool`, optional): Whether to delete the previous index folder once
+  the new one is built and promoted. Defaults to `True`.
+- **use_cpp** (`bool`, optional): Use the native C++ indexing engine instead of the pure
+  Python implementation. Defaults to `False`. See
+  [Using the C++ engine](#using-the-c-engine-use_cpptrue) below.
+
+The following tuning options are accepted as keyword arguments (`**kwargs`):
+
+- **num_of_shards** (`int`, optional): Number of hash-partitioned shards the postings are
+  split across. Defaults to `1`. Controls **search-time** parallelism and storage layout,
+  and is **fixed at creation time** (changing it later requires `ds.reshard_index()`).
+- **num_of_batches** (`int`, optional): Number of independent batches the row range is split
+  into during construction. Defaults to `1`. Controls **build-time** parallelism.
+- **max_workers** (`int`, optional): Upper bound on the number of parallel
+  processes/threads used during build, optimize, and search. Defaults to `16`.
+- **tokenizer** (`str`, optional): Tokenizer for `fuzzy_match`. Defaults to `"jieba"`.
+- **cut_all** (`bool`, optional): Use jieba's full-cut mode. Defaults to `False`.
+- **stop_words_list** (`list[str]`, optional): Extra stop words to ignore during tokenization.
+- **compulsory_words** (`str`, optional): Words that must be kept as a single token.
+- **case_sensitive** (`bool`, optional): Whether matching is case sensitive. Defaults to `False`.
 
 #### Returns
 
 - **None**
+
+#### Choosing `num_of_shards`, `num_of_batches`, and `max_workers`
+
+These three options control different things and are commonly misunderstood. The key point:
+**`max_workers` is only an upper bound** — the parallelism that actually happens is capped by
+how many work units exist.
+
+| Option | Governs | Effective parallelism | Default |
+|---|---|---|---|
+| `num_of_batches` | **Build** (index creation) | `min(num_of_batches, max_workers)` | `1` |
+| `num_of_shards` | **Search & optimize** + storage layout | `min(num_of_shards, max_workers)` | `1` |
+| `max_workers` | Cap on all of the above | — | `16` |
+
+- **`num_of_batches`** splits the dataset row range into independent construction tasks.
+  Because the default is `1`, **raising `max_workers` alone does not parallelize the build** —
+  you must increase `num_of_batches` first. Larger values also give finer restart granularity:
+  if a build is interrupted, only the unfinished batches need to be re-run by calling
+  `create_index_vectorized()` again.
+- **`num_of_shards`** hash-partitions the inverted index. It is persisted in the index
+  metadata at creation time and determines how many shards search and optimization can run in
+  parallel. More shards means more query-time parallelism and smaller per-shard files (good for
+  large datasets / large vocabularies), but too many shards on a small dataset only adds file
+  overhead. To change it after the fact, use `ds.reshard_index()`.
+- **`max_workers`** simply caps parallelism everywhere; set it close to the machine's CPU core
+  count.
+
+**Rules of thumb:**
+
+- **Small datasets:** keep the defaults (`num_of_shards=1`, `num_of_batches=1`, `max_workers=16`).
+- **Large datasets, faster build:** set `num_of_batches` to roughly `max_workers` (or a small
+  multiple) so every worker stays busy, and set `max_workers` near the CPU core count.
+- **High query concurrency / large vocabulary:** increase `num_of_shards` (e.g. into the tens)
+  to parallelize search and keep per-shard files small.
+
+#### Using the C++ engine (`use_cpp=True`)
+
+MULLER ships a native C++ inverted-index engine that is significantly faster than the pure
+Python path for both construction and search. Enable it with `use_cpp=True`. Important
+constraints:
+
+- **Requires the compiled C++ extension.** It is built automatically during a standard
+  `pip install .` (via `muller/util/sparsehash/build_proj.sh`). If MULLER was installed with
+  `BUILD_CPP=false`, the C++ engine is unavailable.
+- **Local datasets only.** The C++ engine reads and writes the local filesystem directly
+  (bypassing MULLER's storage abstraction), so it raises `UnsupportedMethod` on remote-backed
+  datasets (e.g. S3/object storage). Use `use_cpp=False` for those.
+- **`fuzzy_match` only.** Combining `index_type="exact_match"` with `use_cpp=True` raises
+  `UnsupportedMethod`; use the Python engine (`use_cpp=False`) for exact-match indexes.
+
+```python
+import muller
+
+ds = muller.load("./my_dataset")
+ds.commit()  # an index requires a clean (committed) head
+
+# Build a C++ full-text index on a local dataset
+ds.create_index_vectorized("description", use_cpp=True)
+
+# Parallel build on a large local dataset
+ds.create_index_vectorized(
+    "description",
+    use_cpp=True,
+    num_of_batches=16,   # parallelize construction
+    num_of_shards=16,    # parallelize search / shard the postings
+    max_workers=16,      # cap parallelism near CPU core count
+)
+```
 
 #### Examples
 
@@ -280,16 +383,25 @@ Create an index optimized for vectorized operations. This is useful for large-sc
 import muller
 
 ds = muller.load("./my_dataset")
+ds.commit()
 
-# Create vectorized index
-ds.create_index_vectorized("labels")
+# Create a vectorized full-text index (Python engine, defaults)
+ds.create_index_vectorized("description")
 
-# Create with multiple workers for faster indexing
-ds.create_index_vectorized("categories", num_workers=4)
+# Query through the index
+res = ds.filter_vectorized([("description", "CONTAINS", "cat")])
 
-# Create vectorized indexes on multiple tensors
-for tensor_name in ["labels", "user_id", "timestamp"]:
-    ds.create_index_vectorized(tensor_name, num_workers=4)
+# Parallelize the build on a larger dataset
+ds.create_index_vectorized("description", num_of_batches=8, max_workers=8)
+
+# Shard the index for query-time parallelism
+ds.create_index_vectorized("description", num_of_shards=16, max_workers=16)
+
+# Exact-match index (Python engine only)
+ds.create_index_vectorized("categories", index_type="exact_match")
+
+# Rebuild an existing index from scratch instead of appending
+ds.create_index_vectorized("description", force_create=True)
 ```
 
 ---


### PR DESCRIPTION
## Summary

Documents the C++ inverted-index engine (`use_cpp=True`) and the parallelism tuning options of `create_index_vectorized()` (`num_of_shards`, `num_of_batches`, `max_workers`), which were previously undocumented — and, in the API reference, incorrectly documented. Also upgrades the `muller-advanced-query` skill so its `create-index` operation matches the documented behavior.

## Motivation

- The API reference for `ds.create_index_vectorized()` listed parameters that do **not** exist in the real signature (`num_workers`, `scheduler`), while the actual tuning options (`num_of_shards`, `num_of_batches`, `max_workers`) and the `use_cpp` C++ engine were not documented anywhere.
- How to choose these parallelism options is non-obvious: `max_workers` is only an upper bound, and raising it alone does nothing when `num_of_batches`/`num_of_shards` stay at their default of `1`.
- The `muller-advanced-query` skill's `create-index` operation used the legacy `ds.create_index()` API, so it could not expose the C++ engine or tuning options and was inconsistent with the README and API docs.

## Changes

### Documentation

- **`docs/api/dataset-query.md`** — Rewrote the `ds.create_index_vectorized()` section:
  - Fixed the incorrect parameter list to match the real signature (`tensor_column`, `index_type`, `use_uuid`, `force_create`, `delete_old_index`, `use_cpp`, and `**kwargs`).
  - Added a full parameter reference, including the `**kwargs` tuning options.
  - Added a "Choosing `num_of_shards`, `num_of_batches`, and `max_workers`" subsection with a comparison table and rules of thumb.
  - Added a "Using the C++ engine (`use_cpp=True`)" subsection covering its constraints (compiled extension required, local datasets only, `fuzzy_match` only).
- **`README.md`** — Added C++ engine and parallel-build examples plus a tuning note in the Query Data section, linking to the API reference.

### `muller-advanced-query` skill

- **`scripts/advanced_query.py`** — Switched the `create-index` operation from the legacy `ds.create_index()` to `ds.create_index_vectorized()` (looping over columns), and added CLI options: `--index-type`, `--use-cpp`, `--num-of-shards`, `--num-of-batches`, `--max-workers`, `--force-create`. Tuning options are only forwarded when explicitly set, preserving library defaults.
- **`SKILL.md`** — Updated the `create-index` description and usage examples, and added an "Inverted Index Options" section documenting the C++ engine and parallelism tuning.

## Notes

- No library/runtime code was changed; the legacy `ds.create_index()` method remains available and is simply no longer used by this skill.

## Test plan

- [x] `python -m py_compile scripts/advanced_query.py` passes
- [x] `advanced_query.py create-index --help` shows the new options
- [ ] Build an index on a local dataset with `--use-cpp` and verify `filter_vectorized(... CONTAINS ...)`
- [ ] Verify the rendered docs site for the updated `dataset-query` page